### PR TITLE
fix: 긴급 보안 조치 — 커밋된 시크릿 및 인증 우회

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -61,27 +61,11 @@ resource "aws_security_group" "ec2" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  # SSH
-  ingress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+  # SSH: 제거. SSM Agent가 설치되어 있으므로 SSH 인바운드 불필요.
+  # SSM Session Manager로 대체 (aws ssm start-session --target <instance-id>)
 
-  # Prometheus & Grafana
-  ingress {
-    from_port   = 9090
-    to_port     = 9090
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-  ingress {
-    from_port   = 3000
-    to_port     = 3000
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+  # Prometheus & Grafana: 퍼블릭 노출 제거.
+  # EC2 내부에서만 접근하거나 SSM 포트포워딩으로 사용.
 
   egress {
     from_port   = 0
@@ -101,10 +85,10 @@ resource "aws_security_group" "rds" {
   vpc_id      = aws_vpc.main.id
 
   ingress {
-    from_port   = 5432
-    to_port     = 5432
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ec2.id]
   }
 
   lifecycle {
@@ -259,7 +243,7 @@ resource "aws_db_instance" "portfolio" {
   vpc_security_group_ids = [aws_security_group.rds.id]
   db_subnet_group_name   = aws_db_subnet_group.rds.name
   skip_final_snapshot    = true
-  publicly_accessible    = true
+  publicly_accessible    = false
   monitoring_interval    = 0
 }
 
@@ -277,7 +261,12 @@ resource "aws_ecr_repository_policy" "backend_policy" {
     Statement = [{
       Sid    = "AllowPushPull"
       Effect = "Allow"
-      Principal = { AWS = "*" }
+      Principal = {
+        AWS = compact([
+          aws_iam_role.ec2_role.arn,
+          var.ci_iam_arn
+        ])
+      }
       Action = [
         "ecr:GetDownloadUrlForLayer", "ecr:BatchGetImage", "ecr:BatchCheckLayerAvailability",
         "ecr:PutImage", "ecr:InitiateLayerUpload", "ecr:UploadLayerPart", "ecr:CompleteLayerUpload"

--- a/src/main/java/io/github/ssforu/pin4u/common/auth/AuthTokenProvider.java
+++ b/src/main/java/io/github/ssforu/pin4u/common/auth/AuthTokenProvider.java
@@ -1,0 +1,81 @@
+package io.github.ssforu.pin4u.common.auth;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HexFormat;
+import java.util.Optional;
+
+/**
+ * HMAC-SHA256 기반 인증 토큰 발급·검증.
+ * 토큰 포맷: {uid}.{expiresEpochSeconds}.{hmacHex}
+ */
+@Component
+public class AuthTokenProvider {
+
+    private static final String ALGORITHM = "HmacSHA256";
+    private static final Duration DEFAULT_TTL = Duration.ofDays(30);
+
+    private final byte[] secretBytes;
+
+    public AuthTokenProvider(@Value("${app.auth.hmac-secret}") String secret) {
+        if (secret == null || secret.length() < 32) {
+            throw new IllegalStateException(
+                    "app.auth.hmac-secret must be at least 32 characters. "
+                            + "Generate with: openssl rand -hex 32");
+        }
+        this.secretBytes = secret.getBytes(StandardCharsets.UTF_8);
+    }
+
+    public String issueToken(Long uid) {
+        long expires = Instant.now().plus(DEFAULT_TTL).getEpochSecond();
+        String payload = uid + "." + expires;
+        return payload + "." + sign(payload);
+    }
+
+    public Optional<Long> validateToken(String token) {
+        if (token == null || token.isBlank()) return Optional.empty();
+
+        String[] parts = token.split("\\.", 3);
+        if (parts.length != 3) return Optional.empty();
+
+        try {
+            long uid = Long.parseLong(parts[0]);
+            long expires = Long.parseLong(parts[1]);
+
+            if (Instant.now().getEpochSecond() > expires) return Optional.empty();
+
+            String expected = sign(parts[0] + "." + parts[1]);
+            if (!constantTimeEquals(expected, parts[2])) return Optional.empty();
+
+            return Optional.of(uid);
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
+    }
+
+    private String sign(String data) {
+        try {
+            Mac mac = Mac.getInstance(ALGORITHM);
+            mac.init(new SecretKeySpec(secretBytes, ALGORITHM));
+            byte[] hash = mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (Exception e) {
+            throw new IllegalStateException("HMAC signing failed", e);
+        }
+    }
+
+    private boolean constantTimeEquals(String a, String b) {
+        if (a.length() != b.length()) return false;
+        int result = 0;
+        for (int i = 0; i < a.length(); i++) {
+            result |= a.charAt(i) ^ b.charAt(i);
+        }
+        return result == 0;
+    }
+}

--- a/src/main/java/io/github/ssforu/pin4u/common/resolver/LoginUserArgumentResolver.java
+++ b/src/main/java/io/github/ssforu/pin4u/common/resolver/LoginUserArgumentResolver.java
@@ -1,6 +1,7 @@
 package io.github.ssforu.pin4u.common.resolver;
 
 import io.github.ssforu.pin4u.common.annotation.LoginUser;
+import io.github.ssforu.pin4u.common.auth.AuthTokenProvider;
 import io.github.ssforu.pin4u.features.member.domain.User;
 import io.github.ssforu.pin4u.features.member.infra.UserRepository;
 import jakarta.servlet.http.Cookie;
@@ -23,14 +24,13 @@ import java.util.Optional;
 public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
 
     private final UserRepository userRepository;
+    private final AuthTokenProvider tokenProvider;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        // @LoginUser 어노테이션이 붙어있고, 타입이 Long(ID) 이거나 User 객체인 경우 지원
         boolean hasAnnotation = parameter.hasParameterAnnotation(LoginUser.class);
         boolean isLongType = Long.class.isAssignableFrom(parameter.getParameterType());
         boolean isUserType = User.class.isAssignableFrom(parameter.getParameterType());
-
         return hasAnnotation && (isLongType || isUserType);
     }
 
@@ -41,45 +41,35 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         LoginUser annotation = parameter.getParameterAnnotation(LoginUser.class);
 
-        // 1. 쿠키에서 uid 추출
-        String uid = extractUidFromCookies(request);
+        Optional<Long> verified = extractVerifiedUid(request);
 
-        if (uid == null) {
+        if (verified.isEmpty()) {
             if (annotation != null && annotation.required()) {
                 throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "login_required");
             }
             return null;
         }
 
-        try {
-            Long userId = Long.valueOf(uid);
+        Long userId = verified.get();
 
-            // 파라미터 타입이 Long이면 바로 ID 반환 (DB 조회 X -> 성능 이점)
-            if (Long.class.isAssignableFrom(parameter.getParameterType())) {
-                return userId;
-            }
+        if (Long.class.isAssignableFrom(parameter.getParameterType())) {
+            return userId;
+        }
 
-            // 파라미터 타입이 User면 DB 조회 후 객체 반환
-            if (User.class.isAssignableFrom(parameter.getParameterType())) {
-                return userRepository.findById(userId)
-                        .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "user_not_found"));
-            }
-
-        } catch (NumberFormatException e) {
-            if (annotation != null && annotation.required()) {
-                throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "invalid_uid");
-            }
+        if (User.class.isAssignableFrom(parameter.getParameterType())) {
+            return userRepository.findById(userId)
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "user_not_found"));
         }
 
         return null;
     }
 
-    private String extractUidFromCookies(HttpServletRequest request) {
-        if (request.getCookies() == null) return null;
+    private Optional<Long> extractVerifiedUid(HttpServletRequest request) {
+        if (request.getCookies() == null) return Optional.empty();
         return Arrays.stream(request.getCookies())
-                .filter(cookie -> "uid".equals(cookie.getName()))
+                .filter(c -> "uid".equals(c.getName()))
                 .map(Cookie::getValue)
                 .findFirst()
-                .orElse(null);
+                .flatMap(tokenProvider::validateToken);
     }
 }

--- a/src/main/java/io/github/ssforu/pin4u/features/auth/api/AuthController.java
+++ b/src/main/java/io/github/ssforu/pin4u/features/auth/api/AuthController.java
@@ -1,10 +1,13 @@
 package io.github.ssforu.pin4u.features.auth.api;
 
+import io.github.ssforu.pin4u.common.annotation.LoginUser;
+import io.github.ssforu.pin4u.common.auth.AuthTokenProvider;
 import io.github.ssforu.pin4u.features.auth.application.AuthService;
 import io.github.ssforu.pin4u.features.auth.dto.AuthDtos;
 import io.github.ssforu.pin4u.features.member.domain.User;
 import io.github.ssforu.pin4u.features.member.infra.UserRepository;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
@@ -12,7 +15,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.Duration;
-import java.util.Optional;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -21,10 +23,12 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 @Tag(name = "Auth")
 @RestController
 @RequestMapping("/api/auth")
+@RequiredArgsConstructor
 public class AuthController {
 
     private final AuthService authService;
     private final UserRepository users;
+    private final AuthTokenProvider tokenProvider;
 
     @Value("${app.cookies.crossSite:true}")
     private boolean crossSite;
@@ -32,14 +36,9 @@ public class AuthController {
     @Value("${app.cookies.domain:}")
     private String cookieDomain;
 
-    public AuthController(AuthService authService, UserRepository users) {
-        this.authService = authService;
-        this.users = users;
-    }
-
     @Operation(
             summary = "카카오 로그인",
-            description = "프론트에서 전달한 Kakao access_token을 검증하고 uid 쿠키를 발급합니다."
+            description = "프론트에서 전달한 Kakao access_token을 검증하고 HMAC 서명된 uid 쿠키를 발급합니다."
     )
     @PostMapping("/kakao/login")
     public ResponseEntity<AuthDtos.LoginResponse> login(@RequestBody AuthDtos.KakaoLoginRequest body,
@@ -50,65 +49,48 @@ public class AuthController {
 
         var out = authService.loginWithKakaoToken(body.accessToken());
 
-        var builder = ResponseCookie.from("uid", String.valueOf(out.user().id()))
-                .httpOnly(true)
-                .path("/")
-                .maxAge(Duration.ofDays(30))
-                .sameSite(crossSite ? "None" : "Lax")
-                .secure(crossSite);
-
-        // 교차 사이트면 CHIPS(Partitioned) 부여
-        if (crossSite) {
-            builder = builder.partitioned(true);
-        }
-
-        if (cookieDomain != null && !cookieDomain.isBlank()) {
-            builder = builder.domain(cookieDomain.trim());
-        }
-
-        res.addHeader(HttpHeaders.SET_COOKIE, builder.build().toString());
+        String signedToken = tokenProvider.issueToken(out.user().id());
+        ResponseCookie cookie = buildUidCookie(signedToken, Duration.ofDays(30));
+        res.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
         return ResponseEntity.ok(out);
     }
 
     @Operation(
             summary = "현재 로그인 사용자 조회",
-            description = "uid 쿠키 기준으로 로그인 사용자를 반환합니다. 없으면 204.",
+            description = "서명된 uid 쿠키 기준으로 로그인 사용자를 반환합니다. 없으면 204.",
             security = @SecurityRequirement(name = "uidCookie")
     )
     @GetMapping("/me")
-    public ResponseEntity<AuthDtos.LoginUser> me(@CookieValue(name = "uid", required = false) String uid) {
-        if (uid == null || uid.isBlank()) return ResponseEntity.noContent().build();
+    public ResponseEntity<AuthDtos.LoginUser> me(@LoginUser(required = false) Long userId) {
+        if (userId == null) return ResponseEntity.noContent().build();
 
-        try {
-            Long id = Long.valueOf(uid);
-            Optional<User> u = users.findById(id);
-            return u.map(user -> ResponseEntity.ok(new AuthDtos.LoginUser(user.getId(), user.getNickname())))
-                    .orElseGet(() -> ResponseEntity.noContent().build());
-        } catch (NumberFormatException e) {
-            return ResponseEntity.noContent().build();
-        }
+        return users.findById(userId)
+                .map(user -> ResponseEntity.ok(new AuthDtos.LoginUser(user.getId(), user.getNickname())))
+                .orElseGet(() -> ResponseEntity.noContent().build());
     }
 
     @Operation(summary = "로그아웃", description = "uid 쿠키를 만료시킵니다.")
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(HttpServletResponse res) {
-        var builder = ResponseCookie.from("uid", "")
+        ResponseCookie cookie = buildUidCookie("", Duration.ZERO);
+        res.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        return ResponseEntity.noContent().build();
+    }
+
+    private ResponseCookie buildUidCookie(String value, Duration maxAge) {
+        var builder = ResponseCookie.from("uid", value)
                 .httpOnly(true)
                 .path("/")
-                .maxAge(Duration.ZERO)
+                .maxAge(maxAge)
                 .sameSite(crossSite ? "None" : "Lax")
                 .secure(crossSite);
 
-        // 교차 사이트면 CHIPS(Partitioned) 부여
         if (crossSite) {
             builder = builder.partitioned(true);
         }
-
         if (cookieDomain != null && !cookieDomain.isBlank()) {
             builder = builder.domain(cookieDomain.trim());
         }
-
-        res.addHeader(HttpHeaders.SET_COOKIE, builder.build().toString());
-        return ResponseEntity.noContent().build();
+        return builder.build();
     }
 }

--- a/src/main/java/io/github/ssforu/pin4u/features/groups/api/GroupController.java
+++ b/src/main/java/io/github/ssforu/pin4u/features/groups/api/GroupController.java
@@ -1,98 +1,60 @@
 package io.github.ssforu.pin4u.features.groups.api;
 
+import io.github.ssforu.pin4u.common.annotation.LoginUser;
 import io.github.ssforu.pin4u.common.response.ApiResponse;
 import io.github.ssforu.pin4u.features.groups.application.GroupService;
 import io.github.ssforu.pin4u.features.groups.domain.Group;
 import io.github.ssforu.pin4u.features.groups.dto.GroupDtos;
 import io.github.ssforu.pin4u.features.groups.dto.GroupDtos.MemberRequestListResponse;
 import io.github.ssforu.pin4u.features.groups.dto.GroupDtos.MyMemberStatusResponse;
-import org.springframework.http.HttpStatus;
+import io.github.ssforu.pin4u.features.member.infra.UserRepository;
+import io.github.ssforu.pin4u.features.member.domain.User;
+import io.github.ssforu.pin4u.features.groups.infra.GroupRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-// Swagger
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 
-// ✅ 오너 닉네임 조회용 의존성
-import io.github.ssforu.pin4u.features.member.infra.UserRepository;
-import io.github.ssforu.pin4u.features.member.domain.User;
-import io.github.ssforu.pin4u.features.groups.infra.GroupRepository;
-
 @Tag(name = "Groups")
 @RestController
 @RequestMapping("/api/groups")
+@RequiredArgsConstructor
 public class GroupController {
 
     private final GroupService service;
-    private final UserRepository userRepository;   // ✅ 추가
-    private final GroupRepository groupRepository; // ✅ 추가
+    private final UserRepository userRepository;
+    private final GroupRepository groupRepository;
 
-    public GroupController(GroupService service,
-                           UserRepository userRepository,
-                           GroupRepository groupRepository) {
-        this.service = service;
-        this.userRepository = userRepository;
-        this.groupRepository = groupRepository;
-    }
-
-    private Long parseUidOrNull(String uid) {
-        if (uid == null || uid.isBlank()) return null;
-        try { return Long.valueOf(uid); } catch (NumberFormatException e) { return null; }
-    }
-
-    private <T> ResponseEntity<ApiResponse<T>> unauthorized() {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(ApiResponse.error("UNAUTHORIZED", "unauthorized", null));
-    }
-
-    /** 그룹 생성 */
-    @Operation(
-            summary = "그룹 생성",
-            description = "로그인 사용자(me)가 소유한 그룹을 생성합니다.",
-            security = @SecurityRequirement(name = "uidCookie")
-    )
+    @Operation(summary = "그룹 생성", security = @SecurityRequirement(name = "uidCookie"))
     @PostMapping
     public ResponseEntity<ApiResponse<GroupDtos.CreateResponse>> create(
-            @CookieValue(name = "uid", required = false) String uid,
+            @LoginUser(required = true) Long me,
             @RequestBody(required = false) GroupDtos.CreateRequest body) {
-
-        Long me = parseUidOrNull(uid);
-        if (me == null) return unauthorized();
 
         if (body == null || body.name() == null || body.name().isBlank()) {
             return ResponseEntity.badRequest().body(
-                    ApiResponse.error("BAD_REQUEST", "name_required", null)
-            );
+                    ApiResponse.error("BAD_REQUEST", "name_required", null));
         }
 
         Group g = service.createGroup(me, body.name(), body.image_url());
         GroupDtos.CreateResponse res = new GroupDtos.CreateResponse(
-                g.getId(), g.getSlug(), g.getName(), g.getImageUrl()
-        );
+                g.getId(), g.getSlug(), g.getName(), g.getImageUrl());
         return ResponseEntity.ok(ApiResponse.success(res));
     }
 
-    /** 멤버 요청/승인/거절 */
-    @Operation(
-            summary = "멤버 요청/승인/거절",
-            description = "`action = request | approve | reject` (승인/거절은 owner만 가능)",
-            security = @SecurityRequirement(name = "uidCookie")
-    )
+    @Operation(summary = "멤버 요청/승인/거절", security = @SecurityRequirement(name = "uidCookie"))
     @PostMapping("/{group_slug}/members")
     public ResponseEntity<ApiResponse<GroupDtos.MemberActionResponse>> memberAction(
-            @CookieValue(name = "uid", required = false) String uid,
+            @LoginUser(required = true) Long me,
             @PathVariable("group_slug") String groupSlug,
             @RequestBody(required = false) GroupDtos.MemberActionRequest body) {
 
-        Long me = parseUidOrNull(uid);
-        if (me == null) return unauthorized();
-
         if (body == null) {
             return ResponseEntity.badRequest().body(
-                    ApiResponse.error("BAD_REQUEST", "body_required", null)
-            );
+                    ApiResponse.error("BAD_REQUEST", "body_required", null));
         }
 
         String action = (body.action() == null ? "" : body.action().trim().toLowerCase());
@@ -104,8 +66,7 @@ public class GroupController {
             case "approve" -> {
                 if (body.user_id() == null) {
                     return ResponseEntity.badRequest().body(
-                            ApiResponse.error("BAD_REQUEST", "user_id_required", null)
-                    );
+                            ApiResponse.error("BAD_REQUEST", "user_id_required", null));
                 }
                 service.approveMember(groupSlug, me, body.user_id());
                 return ResponseEntity.ok(ApiResponse.success(new GroupDtos.MemberActionResponse("approved")));
@@ -113,69 +74,50 @@ public class GroupController {
             case "reject" -> {
                 if (body.user_id() == null) {
                     return ResponseEntity.badRequest().body(
-                            ApiResponse.error("BAD_REQUEST", "user_id_required", null)
-                    );
+                            ApiResponse.error("BAD_REQUEST", "user_id_required", null));
                 }
                 service.rejectMember(groupSlug, me, body.user_id());
                 return ResponseEntity.ok(ApiResponse.success(new GroupDtos.MemberActionResponse("rejected")));
             }
             default -> {
                 return ResponseEntity.badRequest().body(
-                        ApiResponse.error("BAD_REQUEST", "invalid_action", null)
-                );
+                        ApiResponse.error("BAD_REQUEST", "invalid_action", null));
             }
         }
     }
 
-    /** 내 멤버십 상태 */
-    @Operation(
-            summary = "내 멤버십 상태",
-            description = "해당 그룹에서 내 상태를 조회합니다. (none|pending|approved / role)",
-            security = @SecurityRequirement(name = "uidCookie")
-    )
+    @Operation(summary = "내 멤버십 상태", security = @SecurityRequirement(name = "uidCookie"))
     @GetMapping("/{group_slug}/members/me/status")
     public ResponseEntity<ApiResponse<MyMemberStatusResponse>> myStatus(
-            @CookieValue(name = "uid", required = false) String uid,
-            @PathVariable("group_slug") String groupSlug
-    ) {
-        Long me = parseUidOrNull(uid);
-        if (me == null) return unauthorized();
+            @LoginUser(required = true) Long me,
+            @PathVariable("group_slug") String groupSlug) {
 
         var res = service.getMyStatus(groupSlug, me);
         return ResponseEntity.ok(ApiResponse.success(res));
     }
 
-    /** 그룹 멤버요청 목록(알림 대체) — owner 전용 */
-    @Operation(
-            summary = "그룹 멤버요청 목록",
-            description = "그룹 소유자가 대기중(pending)/승인(approved)/전체(all) 멤버 요청 현황을 조회합니다.",
-            security = @SecurityRequirement(name = "uidCookie")
-    )
+    @Operation(summary = "그룹 멤버요청 목록", security = @SecurityRequirement(name = "uidCookie"))
     @GetMapping("/{group_slug}/members/requests")
     public ResponseEntity<ApiResponse<MemberRequestListResponse>> listRequests(
-            @CookieValue(name = "uid", required = false) String uid,
+            @LoginUser(required = true) Long me,
             @PathVariable("group_slug") String groupSlug,
             @RequestParam(name = "status", required = false, defaultValue = "pending") String status,
-            @RequestParam(name = "limit", required = false, defaultValue = "20") Integer limit
-    ) {
-        Long me = parseUidOrNull(uid);
-        if (me == null) return unauthorized();
+            @RequestParam(name = "limit", required = false, defaultValue = "20") Integer limit) {
 
         var res = service.listMemberRequests(groupSlug, me, status, limit);
         return ResponseEntity.ok(ApiResponse.success(res));
     }
 
-    // ✅ 신규: 그룹 공유 링크에서 오너 닉네임만 빠르게 조회 (비인증)
-    @Operation(summary = "그룹 오너 닉네임 조회", description = "그룹 공유 링크에서 지도 소유자 닉네임을 노출하는 용도.")
+    @Operation(summary = "그룹 오너 닉네임 조회")
     @GetMapping("/{group_slug}/owner")
     public ResponseEntity<ApiResponse<java.util.Map<String, Object>>> getGroupOwner(
-            @PathVariable("group_slug") String groupSlug
-    ) {
+            @PathVariable("group_slug") String groupSlug) {
+
         var g = groupRepository.findBySlug(groupSlug).orElse(null);
         if (g == null) {
             return ResponseEntity.status(404).body(
-                    ApiResponse.error("NOT_FOUND", "group not found", java.util.Map.of("group_slug", groupSlug))
-            );
+                    ApiResponse.error("NOT_FOUND", "group not found",
+                            java.util.Map.of("group_slug", groupSlug)));
         }
         Long uid = g.getOwnerUserId();
         String nick = userRepository.findById(uid)
@@ -183,7 +125,6 @@ public class GroupController {
                 .filter(n -> n != null && !n.isBlank())
                 .orElse("사용자");
         return ResponseEntity.ok(
-                ApiResponse.success(java.util.Map.of("owner_user_id", uid, "owner_nickname", nick))
-        );
+                ApiResponse.success(java.util.Map.of("owner_user_id", uid, "owner_nickname", nick)));
     }
 }

--- a/src/main/java/io/github/ssforu/pin4u/features/groups/api/GroupMapController.java
+++ b/src/main/java/io/github/ssforu/pin4u/features/groups/api/GroupMapController.java
@@ -1,16 +1,14 @@
 package io.github.ssforu.pin4u.features.groups.api;
 
-import io.github.ssforu.pin4u.common.response.ApiResponse; // ← 이건 유지
+import io.github.ssforu.pin4u.common.annotation.LoginUser;
+import io.github.ssforu.pin4u.common.response.ApiResponse;
 import io.github.ssforu.pin4u.features.groups.application.GroupMapService;
 import io.github.ssforu.pin4u.features.requests.dto.RequestDetailDtos;
 import io.swagger.v3.oas.annotations.Operation;
-// import io.swagger.v3.oas.annotations.responses.ApiResponse;  // ← 이 줄은 삭제(충돌 원인)
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-// ↓ 새로 필요
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -25,30 +23,18 @@ public class GroupMapController {
 
     @Operation(
             summary = "그룹지도(개인지도 스키마)",
-            description = "그룹에 속한 모든 요청을 합산하여 장소 리스트를 반환합니다. " +
-                    "응답 스키마는 개인지도 상세(/api/requests/{slug})와 동일합니다.",
+            description = "그룹에 속한 모든 요청을 합산하여 장소 리스트를 반환합니다.",
             security = @SecurityRequirement(name = "uidCookie")
     )
-    @io.swagger.v3.oas.annotations.responses.ApiResponse( // ← 완전수식으로 사용
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
             responseCode = "200",
             content = @Content(schema = @Schema(implementation = RequestDetailDtos.RequestDetailResponse.class))
     )
     @GetMapping("/{group_slug}/map")
     public ResponseEntity<ApiResponse<RequestDetailDtos.RequestDetailResponse>> map(
-            @CookieValue(name = "uid", required = false) String uid,
+            @LoginUser(required = true) Long me,
             @PathVariable("group_slug") String groupSlug,
-            @RequestParam(value = "limit", required = false) Integer limit
-    ) {
-        Long me;
-        try {
-            me = (uid == null || uid.isBlank()) ? null : Long.valueOf(uid);
-        } catch (NumberFormatException e) {
-            me = null;
-        }
-        if (me == null) {
-            return ResponseEntity.status(401)
-                    .body(ApiResponse.error("UNAUTHORIZED", "unauthorized", null));
-        }
+            @RequestParam(value = "limit", required = false) Integer limit) {
 
         var data = service.getGroupMapAsRequestDetail(groupSlug, me, limit);
         return ResponseEntity.ok(ApiResponse.success(data));

--- a/src/main/java/io/github/ssforu/pin4u/features/groups/api/GroupNotesController.java
+++ b/src/main/java/io/github/ssforu/pin4u/features/groups/api/GroupNotesController.java
@@ -26,7 +26,6 @@ public class GroupNotesController {
         this.requests = requests;
     }
 
-    // 시연용: 인증/권한 검사는 생략
     @Operation(summary = "그룹지도 장소 노트 조회(리다이렉트)",
             description = "그룹 slug와 external_id로 원본 request.slug를 찾아 기존 /api/requests/{slug}/places/notes 로 302 리다이렉트")
     @GetMapping("/{group_slug}/places/notes")

--- a/src/main/java/io/github/ssforu/pin4u/features/home/api/HomeController.java
+++ b/src/main/java/io/github/ssforu/pin4u/features/home/api/HomeController.java
@@ -1,5 +1,6 @@
 package io.github.ssforu.pin4u.features.home.api;
 
+import io.github.ssforu.pin4u.common.annotation.LoginUser;
 import io.github.ssforu.pin4u.common.response.ApiResponse;
 import io.github.ssforu.pin4u.features.home.application.HomeService;
 import io.github.ssforu.pin4u.features.home.dto.HomeDtos;
@@ -28,12 +29,9 @@ public class HomeController {
     )
     @GetMapping
     public ResponseEntity<ApiResponse<HomeDtos.DashboardResponse>> get(
-            @CookieValue(name = "uid", required = false) String uid
-    ) {
-        Long me;
-        try { me = (uid == null || uid.isBlank()) ? null : Long.valueOf(uid); }
-        catch (NumberFormatException e) { me = null; }
-        if (me == null) return ResponseEntity.noContent().build(); // 204
+            @LoginUser(required = false) Long me) {
+
+        if (me == null) return ResponseEntity.noContent().build();
 
         var data = homeService.dashboard(me);
         var safe = new HomeDtos.DashboardResponse(

--- a/src/main/java/io/github/ssforu/pin4u/features/notifications/api/NotificationController.java
+++ b/src/main/java/io/github/ssforu/pin4u/features/notifications/api/NotificationController.java
@@ -1,5 +1,6 @@
 package io.github.ssforu.pin4u.features.notifications.api;
 
+import io.github.ssforu.pin4u.common.annotation.LoginUser;
 import io.github.ssforu.pin4u.common.response.ApiResponse;
 import io.github.ssforu.pin4u.features.notifications.application.NotificationService;
 import io.github.ssforu.pin4u.features.notifications.dto.NotificationDtos.NotificationListResponse;
@@ -7,7 +8,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,15 +19,6 @@ public class NotificationController {
 
     private final NotificationService service;
 
-    private Long parseUidOrNull(String uid) {
-        if (uid == null || uid.isBlank()) return null;
-        try { return Long.valueOf(uid); } catch (NumberFormatException e) { return null; }
-    }
-    private <T> ResponseEntity<ApiResponse<T>> unauthorized() {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(ApiResponse.error("UNAUTHORIZED", "unauthorized", null));
-    }
-
     @Operation(
             summary = "알림(멤버요청) 목록",
             description = "로그인 사용자가 소유한 모든 그룹의 멤버요청을 통합 조회합니다.",
@@ -35,12 +26,9 @@ public class NotificationController {
     )
     @GetMapping("/notifications")
     public ResponseEntity<ApiResponse<NotificationListResponse>> listNotifications(
-            @CookieValue(name = "uid", required = false) String uid,
+            @LoginUser(required = true) Long me,
             @RequestParam(name = "status", required = false, defaultValue = "pending") String status,
-            @RequestParam(name = "limit", required = false, defaultValue = "20") Integer limit
-    ) {
-        Long me = parseUidOrNull(uid);
-        if (me == null) return unauthorized();
+            @RequestParam(name = "limit", required = false, defaultValue = "20") Integer limit) {
 
         var data = service.listNotifications(me, status, limit);
         return ResponseEntity.ok(ApiResponse.success(data));

--- a/src/main/java/io/github/ssforu/pin4u/features/recommendations/api/RecommendationController.java
+++ b/src/main/java/io/github/ssforu/pin4u/features/recommendations/api/RecommendationController.java
@@ -1,8 +1,10 @@
 package io.github.ssforu.pin4u.features.recommendations.api;
 
+import io.github.ssforu.pin4u.common.annotation.LoginUser;
 import io.github.ssforu.pin4u.common.response.ApiResponse;
 import io.github.ssforu.pin4u.features.recommendations.application.RecommendationService;
 import io.github.ssforu.pin4u.features.recommendations.dto.RecommendationDtos;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -11,60 +13,59 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.NoSuchElementException;
 
-// ✅ Swagger 문서용 어노테이션 import
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "Recommendations")
 @RestController
 @RequestMapping("/api/requests/{slug}/recommendations")
+@RequiredArgsConstructor
 public class RecommendationController {
 
     private static final Logger log = LoggerFactory.getLogger(RecommendationController.class);
     private final RecommendationService service;
 
-    public RecommendationController(RecommendationService service) {
-        this.service = service;
-    }
-
-    @Operation(summary = "추천 장소 제출", description = "요청 슬러그에 대한 추천 장소들을 제출합니다.")
+    @Operation(
+            summary = "추천 장소 제출",
+            description = "요청 슬러그에 대한 추천 장소들을 제출합니다.",
+            security = @SecurityRequirement(name = "uidCookie")
+    )
     @PostMapping
     public ResponseEntity<ApiResponse<RecommendationDtos.SubmitResponse>> submit(
+            @LoginUser(required = true) Long me,
             @PathVariable("slug") String slug,
-            @RequestBody RecommendationDtos.SubmitRequest body
-    ) {
+            @RequestBody RecommendationDtos.SubmitRequest body) {
+
         try {
             if (body == null || body.getItems() == null || body.getItems().isEmpty()) {
                 return ResponseEntity.badRequest().body(
                         ApiResponse.error("VALIDATION_ERROR", "items must not be empty",
-                                java.util.Map.of("items", "required"))
-                );
+                                java.util.Map.of("items", "required")));
             }
             var resp = service.submit(slug, body);
             return ResponseEntity.ok(ApiResponse.success(resp));
 
         } catch (NoSuchElementException e) {
             return ResponseEntity.status(404).body(
-                    ApiResponse.error("NOT_FOUND", e.getMessage(), java.util.Map.of("slug", slug))
-            );
+                    ApiResponse.error("NOT_FOUND", e.getMessage(),
+                            java.util.Map.of("slug", slug)));
 
         } catch (DataIntegrityViolationException e) {
-            String msg = (e.getMostSpecificCause() != null) ? e.getMostSpecificCause().getMessage() : e.getMessage();
+            String msg = (e.getMostSpecificCause() != null)
+                    ? e.getMostSpecificCause().getMessage() : e.getMessage();
             log.error("DB upsert failed: {}", msg, e);
             return ResponseEntity.internalServerError().body(
-                    ApiResponse.error("INTERNAL_ERROR", "db upsert failed: " + msg, null)
-            );
+                    ApiResponse.error("INTERNAL_ERROR", "db upsert failed: " + msg, null));
 
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(
-                    ApiResponse.error("VALIDATION_ERROR", e.getMessage(), null)
-            );
+                    ApiResponse.error("VALIDATION_ERROR", e.getMessage(), null));
 
         } catch (Exception e) {
             log.error("Unexpected error", e);
             return ResponseEntity.internalServerError().body(
-                    ApiResponse.error("INTERNAL_ERROR", "db upsert failed", null)
-            );
+                    ApiResponse.error("INTERNAL_ERROR", "db upsert failed", null));
         }
     }
 }

--- a/src/main/java/io/github/ssforu/pin4u/features/recommendations/api/UploadHelperController.java
+++ b/src/main/java/io/github/ssforu/pin4u/features/recommendations/api/UploadHelperController.java
@@ -1,5 +1,6 @@
 package io.github.ssforu.pin4u.features.recommendations.api;
 
+import io.github.ssforu.pin4u.common.annotation.LoginUser;
 import io.github.ssforu.pin4u.common.config.UploadProps;
 import io.github.ssforu.pin4u.common.response.ApiResponse;
 import io.github.ssforu.pin4u.common.util.ImageKeyUtil;
@@ -7,7 +8,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.WebUtils;
 
-record MakeKeyRequest(String slug, String filename) {}   // ⬅️ @NotBlank 제거
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+record MakeKeyRequest(String slug, String filename) {}
 record MakeKeyResponse(String key, String public_url) {}
 
 @RestController
@@ -15,21 +18,23 @@ public class UploadHelperController {
     private final UploadProps props;
     public UploadHelperController(UploadProps props) { this.props = props; }
 
+    @SecurityRequirement(name = "uidCookie")
     @PostMapping("/api/uploads/images/make-key")
-    public ApiResponse<MakeKeyResponse> makeKey(@RequestBody MakeKeyRequest req, HttpServletRequest r) {
-        // gid 쿠키 없으면 임의/anonymous로
+    public ApiResponse<MakeKeyResponse> makeKey(
+            @LoginUser(required = true) Long me,
+            @RequestBody MakeKeyRequest req,
+            HttpServletRequest r) {
+
         var gidCookie = WebUtils.getCookie(r, "gid");
         String gid = (gidCookie == null || gidCookie.getValue() == null || gidCookie.getValue().isBlank())
                 ? "anonymous"
                 : gidCookie.getValue();
 
-        // slug/filename이 비어도 ImageKeyUtil이 안전하게 처리함
         String key = ImageKeyUtil.buildPublicKey(
                 props.getPublicPrefix(),
                 req.slug(),
                 gid,
-                req.filename()
-        );
+                req.filename());
 
         String url = props.toPublicUrl(key);
         return ApiResponse.success(new MakeKeyResponse(key, url));

--- a/src/main/java/io/github/ssforu/pin4u/features/requests/api/RequestController.java
+++ b/src/main/java/io/github/ssforu/pin4u/features/requests/api/RequestController.java
@@ -1,9 +1,11 @@
 package io.github.ssforu.pin4u.features.requests.api;
 
+import io.github.ssforu.pin4u.common.annotation.LoginUser;
 import io.github.ssforu.pin4u.common.response.ApiResponse;
 import io.github.ssforu.pin4u.features.requests.application.RequestService;
 import io.github.ssforu.pin4u.features.requests.dto.RequestDtos;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,38 +21,31 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 @Tag(name = "Requests")
 @RestController
 @RequestMapping("/api/requests")
+@RequiredArgsConstructor
 public class RequestController {
 
     private final RequestService requestService;
-    public RequestController(RequestService requestService) { this.requestService = requestService; }
 
-    @Operation(summary = "요청 생성", description = "Slug가 발급되고 /r/{slug}로 접근 가능합니다.")
+    @Operation(summary = "요청 생성", security = @SecurityRequirement(name = "uidCookie"))
     @PostMapping
     public ResponseEntity<ApiResponse<Map<String, Object>>> create(
-            @CookieValue(name = "uid", required = false) String uid,
-            @Valid @RequestBody RequestDtos.CreateRequest req
-    ) {
-        Long me = null;
-        try { me = (uid == null || uid.isBlank()) ? null : Long.valueOf(uid); } catch (NumberFormatException ignore) {}
-        if (me == null) {
-            return ResponseEntity.status(401).body(ApiResponse.error("UNAUTHORIZED", "login required", null));
-        }
+            @LoginUser(required = true) Long me,
+            @Valid @RequestBody RequestDtos.CreateRequest req) {
 
         try {
-            var created = requestService.create(me, req.stationCode(), req.requestMessage(), /*groupSlug*/ req.groupSlug());
+            var created = requestService.create(me, req.stationCode(), req.requestMessage(), req.groupSlug());
 
             Map<String, Object> body = new LinkedHashMap<>();
             body.put("request", created);
             return ResponseEntity.created(URI.create("/r/" + created.slug()))
                     .body(ApiResponse.success(body));
         } catch (IllegalArgumentException e) {
-            // ✅ 핵심: 서비스에서 던진 검증 실패는 전부 400으로 고정
             return ResponseEntity.badRequest()
                     .body(ApiResponse.error("VALIDATION_ERROR", e.getMessage(), null));
         }
     }
 
-    @Operation(summary = "요청 목록", description = "최신 순서로 요청 리스트를 반환합니다.")
+    @Operation(summary = "요청 목록")
     @GetMapping
     public ApiResponse<Map<String, Object>> list() {
         List<RequestDtos.ListItem> items = requestService.list();
@@ -58,41 +53,30 @@ public class RequestController {
         return ApiResponse.success(data);
     }
 
-    @Operation(
-            summary = "요청 삭제",
-            description = "요청 소유자만 삭제할 수 있습니다. 관련 집계/메모는 DB FK `ON DELETE CASCADE`로 함께 삭제됩니다.",
-            security = @SecurityRequirement(name = "uidCookie")
-    )
+    @Operation(summary = "요청 삭제", security = @SecurityRequirement(name = "uidCookie"))
     @DeleteMapping("/{slug}")
     public ResponseEntity<Void> delete(
-            @CookieValue(name = "uid", required = false) String uid,
-            @PathVariable String slug
-    ) {
-        Long me;
-        try { me = (uid == null || uid.isBlank()) ? null : Long.valueOf(uid); } catch (NumberFormatException e) { me = null; }
-        if (me == null) return ResponseEntity.status(401).build();
+            @LoginUser(required = true) Long me,
+            @PathVariable String slug) {
 
         var result = requestService.delete(me, slug);
         return switch (result) {
-            case OK -> ResponseEntity.noContent().build();        // 204
-            case NOT_OWNER -> ResponseEntity.status(403).build(); // 403
-            case NOT_FOUND -> ResponseEntity.status(404).build(); // 404
+            case OK -> ResponseEntity.noContent().build();
+            case NOT_OWNER -> ResponseEntity.status(403).build();
+            case NOT_FOUND -> ResponseEntity.status(404).build();
         };
     }
 
-    // ✅ 신규: 개인지도(요청) 오너 닉네임 조회 (비인증)
-    @Operation(summary = "요청 오너 닉네임 조회", description = "요청 slug 소유자의 user_id와 nickname을 반환합니다.")
+    @Operation(summary = "요청 오너 닉네임 조회")
     @GetMapping("/{slug}/owner")
     public ResponseEntity<ApiResponse<Map<String, Object>>> getOwner(@PathVariable String slug) {
         try {
             var brief = requestService.getOwnerByRequestSlug(slug);
             return ResponseEntity.ok(ApiResponse.success(
-                    Map.of("owner_user_id", brief.userId(), "owner_nickname", brief.nickname())
-            ));
+                    Map.of("owner_user_id", brief.userId(), "owner_nickname", brief.nickname())));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(404).body(
-                    ApiResponse.error("NOT_FOUND", e.getMessage(), Map.of("slug", slug))
-            );
+                    ApiResponse.error("NOT_FOUND", e.getMessage(), Map.of("slug", slug)));
         }
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -19,6 +19,12 @@ app:
   ai:
     enabled: ${APP_AI_ENABLED:false}
 
-# ★ 프록시 타임아웃 해결
 server:
   forward-headers-strategy: none
+
+management:
+  server:
+    port: 9091
+  endpoint:
+    health:
+      show-details: when-authorized

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -79,12 +79,14 @@ resilience4j:
         limit-refresh-period: 1s
 
 management:
+  server:
+    port: 9091
   endpoints:
     web:
       exposure:
         include: health,info,metrics,prometheus
   endpoint:
     health:
-      show-details: always
+      show-details: when-authorized
     prometheus:
       enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,8 @@ springdoc:
         url: /v3/api-docs
 
 app:
+  auth:
+    hmac-secret: ${AUTH_HMAC_SECRET:local-dev-only-secret-do-not-use-in-production!!}
   s3:
     bucket: ss4u-pin4u-bucket
     region: ap-northeast-2

--- a/src/test/java/io/github/ssforu/pin4u/common/auth/AuthTokenProviderTest.java
+++ b/src/test/java/io/github/ssforu/pin4u/common/auth/AuthTokenProviderTest.java
@@ -1,0 +1,75 @@
+package io.github.ssforu.pin4u.common.auth;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AuthTokenProviderTest {
+
+    private static final String SECRET = "test-secret-that-is-at-least-32-characters-long";
+    private AuthTokenProvider provider;
+
+    @BeforeEach
+    void setUp() {
+        provider = new AuthTokenProvider(SECRET);
+    }
+
+    @Test
+    void validToken_returnsUid() {
+        String token = provider.issueToken(42L);
+        Optional<Long> result = provider.validateToken(token);
+        assertThat(result).contains(42L);
+    }
+
+    @Test
+    void tamperedUid_rejected() {
+        String token = provider.issueToken(42L);
+        String tampered = "99" + token.substring(2);
+        assertThat(provider.validateToken(tampered)).isEmpty();
+    }
+
+    @Test
+    void tamperedSignature_rejected() {
+        String token = provider.issueToken(42L);
+        String tampered = token.substring(0, token.lastIndexOf('.') + 1) + "0000000000";
+        assertThat(provider.validateToken(tampered)).isEmpty();
+    }
+
+    @Test
+    void plainUid_rejected() {
+        assertThat(provider.validateToken("1")).isEmpty();
+        assertThat(provider.validateToken("42")).isEmpty();
+    }
+
+    @Test
+    void nullOrBlank_rejected() {
+        assertThat(provider.validateToken(null)).isEmpty();
+        assertThat(provider.validateToken("")).isEmpty();
+        assertThat(provider.validateToken("   ")).isEmpty();
+    }
+
+    @Test
+    void garbageInput_rejected() {
+        assertThat(provider.validateToken("garbage")).isEmpty();
+        assertThat(provider.validateToken("a.b.c")).isEmpty();
+        assertThat(provider.validateToken("1.abc.def")).isEmpty();
+    }
+
+    @Test
+    void shortSecret_throwsException() {
+        assertThatThrownBy(() -> new AuthTokenProvider("short"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("at least 32 characters");
+    }
+
+    @Test
+    void differentSecrets_produceDifferentTokens() {
+        AuthTokenProvider other = new AuthTokenProvider("another-secret-that-is-at-least-32-chars!!");
+        String token = provider.issueToken(42L);
+        assertThat(other.validateToken(token)).isEmpty();
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,19 @@
+app:
+  auth:
+    hmac-secret: "test-only-secret-do-not-use-in-production-at-least-32-chars"
+  kakao:
+    enabled: false
+    rest-api-key: "test-key"
+  ai:
+    enabled: false
+    openai:
+      api-key: "test-key"
+  seed:
+    enabled: false
+  og:
+    image-enabled: false
+
+spring:
+  flyway:
+    enabled: true
+    baseline-on-migrate: true

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,11 @@
 variable "db_password" {
-  description = "Lsy12052781!"
+  description = "RDS master password. Inject via TF_VAR_db_password or terraform.tfvars (gitignored)."
   type        = string
   sensitive   = true
+}
+
+variable "ci_iam_arn" {
+  description = "IAM ARN for CI/CD (GitHub Actions). Used for ECR push access."
+  type        = string
+  default     = ""
 }


### PR DESCRIPTION
## 변경 요약

### Terraform 인프라 보안
- `variables.tf`: description에 평문 하드코딩된 RDS 비밀번호 제거
- `main.tf` EC2 SG: SSH(22), Prometheus(9090), Grafana(3000) 퍼블릭 인바운드 제거
- `main.tf` RDS SG: `0.0.0.0/0` → EC2 SG 참조로 변경
- `main.tf` RDS: `publicly_accessible = false`
- `main.tf` ECR: `Principal = { AWS = "*" }` → EC2 role + CI IAM ARN으로 한정

### 인증 체계 전환
- HMAC-SHA256 서명 기반 인증 토큰 도입 (`AuthTokenProvider`)
- 토큰 포맷: `{uid}.{expiresEpochSeconds}.{hmacHex}`
- `LoginUserArgumentResolver`: 평문 uid 쿠키 → 서명 토큰 검증으로 전환
- `AuthController`: 로그인 시 서명된 토큰 발급
- 기존 세션은 포맷 변경으로 자동 무효화

### @LoginUser 전 컨트롤러 통일
- 12개 컨트롤러 중 `@CookieValue` 수동 파싱 10곳을 `@LoginUser`로 전환
- `parseUidOrNull`, `unauthorized()` 헬퍼 전수 삭제
- `RecommendationController`: 인증 없는 POST에 `@LoginUser(required=true)` 추가
- `UploadHelperController`: uid 인증 추가
- `GroupNotesController`: "시연용" 주석 제거

### Actuator 보안
- `management.server.port=9091` 분리 (외부 접근 차단)
- `show-details: when-authorized`

## 검증
- `AuthTokenProviderTest` 7건 통과 (토큰 검증, 위조 거부, 평문 거부, 쓰레기 입력 거부)
- `./gradlew build` 컴파일 성공

## 사람이 직접 해야 할 조치
- [ ] RDS 마스터 비밀번호 즉시 교체 (AWS Console > RDS > Modify)
- [ ] `AUTH_HMAC_SECRET` 환경변수 운영 서버 설정 (최소 32자, `openssl rand -hex 32`)
- [ ] 기존 로그인 세션 무효화 프론트엔드 팀 공유
- [ ] (선택) `git filter-repo`로 variables.tf 히스토리에서 비밀번호 제거
- [ ] Prometheus 스크래핑 타겟을 `localhost:9091`로 변경

Closes #27