### PR TITLE
feat: 테스트 실행 정상화 및 검증 인프라 구축

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+
+      - run: ./gradlew build integrationTest jacocoTestReport
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-reports
+          path: |
+            build/reports/tests/
+            build/reports/jacoco/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,19 +13,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
+          cache: gradle
 
       - name: Build with Gradle
         run: ./gradlew build
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -33,7 +34,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Build and push Docker image
         env:
@@ -48,7 +49,7 @@ jobs:
           RDS_PASSWORD="$(printf '%s' '${{ secrets.RDS_PASSWORD }}' | tr -d '\r\n')"
           IMAGE="${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}"
           DB_URL="jdbc:postgresql://${RDS_ENDPOINT}/pin4u_be"
-          
+
           aws ssm send-command \
             --instance-ids "${{ secrets.EC2_INSTANCE_ID }}" \
             --document-name "AWS-RunShellScript" \
@@ -62,6 +63,7 @@ jobs:
                 -e SPRING_DATASOURCE_URL=\\\"${DB_URL}\\\" \
                 -e SPRING_DATASOURCE_USERNAME=\\\"pin4u\\\" \
                 -e SPRING_DATASOURCE_PASSWORD=\\\"${RDS_PASSWORD}\\\" \
+                -e AUTH_HMAC_SECRET=\\\"${{ secrets.AUTH_HMAC_SECRET }}\\\" \
                 -e APP_KAKAO_ENABLED=false \
                 -e APP_AI_ENABLED=false \
                 ${IMAGE}\"

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.springframework.boot' version '3.5.4'
     id 'io.spring.dependency-management' version '1.1.7'
     id "org.flywaydb.flyway" version "11.7.2"
+    id 'jacoco'
 }
 
 flyway {
@@ -64,9 +65,26 @@ dependencies {
 }
 
 tasks.withType(Test).configureEach {
-    useJUnitPlatform()
-    onlyIf { project.hasProperty("withTests") }
-    systemProperty "spring.testcontainers.enabled", "false"
+    useJUnitPlatform {
+        excludeTags 'integration'
+    }
+}
+
+tasks.register('integrationTest', Test) {
+    description = 'Runs integration tests requiring Docker (Testcontainers)'
+    group = 'verification'
+    useJUnitPlatform {
+        includeTags 'integration'
+    }
+    shouldRunAfter test
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+    }
 }
 
 springBoot {

--- a/src/test/java/io/github/ssforu/pin4u/FlywayMigrationTest.java
+++ b/src/test/java/io/github/ssforu/pin4u/FlywayMigrationTest.java
@@ -1,0 +1,37 @@
+package io.github.ssforu.pin4u;
+
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationInfo;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Tag("integration")
+@SpringBootTest
+@Import(TestcontainersConfiguration.class)
+class FlywayMigrationTest {
+
+    @Autowired
+    private Flyway flyway;
+
+    @Test
+    void allMigrations_applySuccessfully() {
+        var info = flyway.info();
+        MigrationInfo[] applied = info.applied();
+
+        assertThat(applied).isNotEmpty();
+
+        for (MigrationInfo migration : applied) {
+            assertThat(migration.getState().isFailed())
+                    .as("Migration %s should not be failed", migration.getVersion())
+                    .isFalse();
+        }
+
+        assertThat(info.current()).isNotNull();
+        assertThat(info.current().getState().isFailed()).isFalse();
+    }
+}

--- a/src/test/java/io/github/ssforu/pin4u/Pin4uApplicationTests.java
+++ b/src/test/java/io/github/ssforu/pin4u/Pin4uApplicationTests.java
@@ -1,9 +1,11 @@
 package io.github.ssforu.pin4u;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 
+@Tag("integration")
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
 class Pin4uApplicationTests {

--- a/src/test/java/io/github/ssforu/pin4u/TestcontainersConfiguration.java
+++ b/src/test/java/io/github/ssforu/pin4u/TestcontainersConfiguration.java
@@ -7,12 +7,12 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @TestConfiguration(proxyBeanMethods = false)
-class TestcontainersConfiguration {
+public class TestcontainersConfiguration {
 
-	@Bean
-	@ServiceConnection
-	PostgreSQLContainer<?> postgresContainer() {
-		return new PostgreSQLContainer<>(DockerImageName.parse("postgres:latest"));
-	}
-
+    @Bean
+    @ServiceConnection
+    PostgreSQLContainer<?> postgresContainer() {
+        return new PostgreSQLContainer<>(DockerImageName.parse("postgres:16-alpine"))
+                .withReuse(true);
+    }
 }

--- a/src/test/java/io/github/ssforu/pin4u/features/stations/api/StationControllerTest.java
+++ b/src/test/java/io/github/ssforu/pin4u/features/stations/api/StationControllerTest.java
@@ -1,0 +1,36 @@
+package io.github.ssforu.pin4u.features.stations.api;
+
+import io.github.ssforu.pin4u.TestcontainersConfiguration;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Tag("integration")
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import(TestcontainersConfiguration.class)
+class StationControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    void search_returnsOk() throws Exception {
+        mvc.perform(get("/api/stations/search").param("q", "강남"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value("success"));
+    }
+
+    @Test
+    void search_missingParam_returns400() throws Exception {
+        mvc.perform(get("/api/stations/search"))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## 변경 요약

- onlyIf { hasProperty("withTests") } 제거 → `./gradlew build`로 테스트 실행
- JaCoCo 플러그인 추가
- unit/integration 테스트 분리 (@Tag("integration") + 별도 Gradle task)
- Testcontainers: postgres:16-alpine + withReuse(true)
- FlywayMigrationTest, StationControllerTest 추가
- ci.yml 신규 (PR/push 트리거, temurin 17, gradle 캐시)
- deploy.yml 액션 v4 갱신 + AUTH_HMAC_SECRET 전달

Closes #30