### PR TITLE
feat: 외부 HTTP 클라이언트 타임아웃 및 커넥션 설정 적용

### DIFF
--- a/src/main/java/io/github/ssforu/pin4u/common/config/OpenAiClientConfig.java
+++ b/src/main/java/io/github/ssforu/pin4u/common/config/OpenAiClientConfig.java
@@ -1,14 +1,17 @@
-// src/main/java/io/github/ssforu/pin4u/common/config/OpenAiClientConfig.java
 package io.github.ssforu.pin4u.common.config;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
 
 @Configuration
 public class OpenAiClientConfig {
@@ -19,20 +22,28 @@ public class OpenAiClientConfig {
     public WebClient openaiWebClient(
             WebClient.Builder builder,
             @Value("${app.ai.openai.base-url:https://api.openai.com/v1}") String baseUrl,
-            @Value("${app.ai.openai.api-key:}") String apiKey
+            @Value("${app.ai.openai.api-key:}") String apiKey,
+            @Value("${app.http.openai.connect-timeout:2s}") Duration connectTimeout,
+            @Value("${app.http.openai.response-timeout:20s}") Duration responseTimeout
     ) {
-        // 키가 없어도 빈은 생성합니다. 호출 시 401 나도 서비스단에서 폴백하므로 안전.
-        if (apiKey == null || apiKey.isBlank()) {
-            log.warn("[OPENAI] API key is empty. Calls may 401, but service will fallback.");
-            return builder.baseUrl(baseUrl).build();
-        }
-        return builder
+        // 비동기 백그라운드 호출이므로 response timeout을 여유 있게 설정 (20s).
+        // GPT 응답은 모델/프롬프트에 따라 10s+ 소요될 수 있다.
+        HttpClient httpClient = WebClientConfig.buildHttpClient(connectTimeout, responseTimeout);
+
+        var b = builder
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
                 .baseUrl(baseUrl)
-                .defaultHeader("Authorization", "Bearer " + apiKey)
-                .defaultHeader("User-Agent", "pin4u")
                 .exchangeStrategies(ExchangeStrategies.builder()
                         .codecs(c -> c.defaultCodecs().maxInMemorySize(2 * 1024 * 1024))
-                        .build())
+                        .build());
+
+        if (apiKey == null || apiKey.isBlank()) {
+            log.warn("[OPENAI] API key is empty. Calls may 401, but service will fallback.");
+            return b.build();
+        }
+        return b
+                .defaultHeader("Authorization", "Bearer " + apiKey)
+                .defaultHeader("User-Agent", "pin4u")
                 .build();
     }
 }

--- a/src/main/java/io/github/ssforu/pin4u/common/config/WebClientConfig.java
+++ b/src/main/java/io/github/ssforu/pin4u/common/config/WebClientConfig.java
@@ -1,11 +1,19 @@
 package io.github.ssforu.pin4u.common.config;
 
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 @Configuration
 public class WebClientConfig {
@@ -16,32 +24,55 @@ public class WebClientConfig {
     public WebClient kakaoWebClient(
             WebClient.Builder builder,
             @Value("${app.kakao.enabled:true}") boolean enabled,
-            // base-url은 없으면 기본값 사용
             @Value("${app.kakao.api.base-url:https://dapi.kakao.com}") String baseUrl,
-            // api.key 우선, 없으면 rest-api-key 사용(둘 다 없으면 빈 문자열)
             @Value("${app.kakao.api.key:}") String apiKeyFromApi,
-            @Value("${app.kakao.rest-api-key:}") String apiKeyFromRest
+            @Value("${app.kakao.rest-api-key:}") String apiKeyFromRest,
+            @Value("${app.http.kakao-search.connect-timeout:2s}") Duration connectTimeout,
+            @Value("${app.http.kakao-search.response-timeout:3s}") Duration responseTimeout
     ) {
         final String apiKey = (apiKeyFromApi != null && !apiKeyFromApi.isBlank())
                 ? apiKeyFromApi
                 : (apiKeyFromRest != null ? apiKeyFromRest : "");
 
-        if (!enabled) {
-            // 기능 비활성: 호출 쪽(KakaoSearchAdapterImpl)이 enabled=false로 자체 차단
-            log.info("[KAKAO] disabled by config. base={}", baseUrl);
-            return builder.baseUrl(baseUrl).build();
-        }
+        // 사용자 응답 경로이므로 타임아웃을 짧게 설정 (connect 2s, response 3s)
+        HttpClient httpClient = buildHttpClient(connectTimeout, responseTimeout);
+        var b = builder
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .baseUrl(baseUrl);
 
+        if (!enabled) {
+            log.info("[KAKAO] disabled by config. base={}", baseUrl);
+            return b.build();
+        }
         if (apiKey.isBlank()) {
-            // 기능은 켜져 있지만 키가 없음 → 런타임 호출 시 401 날 수 있으나, 앱은 부팅 성공
-            log.warn("[KAKAO] enabled=true 이지만 API 키가 없습니다. Authorization 없이 생성합니다. (호출 시 401 가능)");
-            return builder.baseUrl(baseUrl).build();
+            log.warn("[KAKAO] enabled=true but API key is empty.");
+            return b.build();
         }
 
         log.info("[KAKAO] enabled. base={}, key.len={}", baseUrl, apiKey.length());
+        return b.defaultHeader("Authorization", "KakaoAK " + apiKey).build();
+    }
+
+    @Bean
+    public WebClient kakaoOAuthWebClient(
+            WebClient.Builder builder,
+            @Value("${app.http.kakao-oauth.connect-timeout:2s}") Duration connectTimeout,
+            @Value("${app.http.kakao-oauth.response-timeout:3s}") Duration responseTimeout
+    ) {
+        // 로그인 경로. 실패 시 사용자에게 즉시 재시도를 유도해야 하므로 짧은 타임아웃.
+        HttpClient httpClient = buildHttpClient(connectTimeout, responseTimeout);
         return builder
-                .baseUrl(baseUrl)
-                .defaultHeader("Authorization", "KakaoAK " + apiKey)
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .baseUrl("https://kapi.kakao.com")
                 .build();
+    }
+
+    static HttpClient buildHttpClient(Duration connectTimeout, Duration responseTimeout) {
+        return HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) connectTimeout.toMillis())
+                .responseTimeout(responseTimeout)
+                .doOnConnected(conn -> conn
+                        .addHandlerLast(new ReadTimeoutHandler(responseTimeout.toSeconds(), TimeUnit.SECONDS))
+                        .addHandlerLast(new WriteTimeoutHandler(responseTimeout.toSeconds(), TimeUnit.SECONDS)));
     }
 }

--- a/src/main/java/io/github/ssforu/pin4u/features/auth/infra/KakaoOAuthClient.java
+++ b/src/main/java/io/github/ssforu/pin4u/features/auth/infra/KakaoOAuthClient.java
@@ -1,18 +1,17 @@
-// src/main/java/io/github/ssforu/pin4u/features/auth/infra/KakaoOAuthClient.java
 package io.github.ssforu.pin4u.features.auth.infra;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
 @Component
+@RequiredArgsConstructor
 public class KakaoOAuthClient {
-    private final WebClient http = WebClient.builder()
-            .baseUrl("https://kapi.kakao.com")       // ★ 사용자 API는 kapi
-            .defaultHeader(HttpHeaders.USER_AGENT, "pin4u")
-            .build();
+
+    private final WebClient kakaoOAuthWebClient;
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record KakaoProfile(String nickname) {}
@@ -24,11 +23,10 @@ public class KakaoOAuthClient {
     public record KakaoMe(long id, KakaoAccount kakao_account) {}
 
     public Mono<KakaoMe> getMe(String accessToken) {
-        return http.get()
+        return kakaoOAuthWebClient.get()
                 .uri("/v2/user/me")
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
                 .retrieve()
-                // ★ 상태별 예외 매핑 추가
                 .onStatus(s -> s.value() == 401,
                         resp -> resp.bodyToMono(String.class)
                                 .defaultIfEmpty("")

--- a/src/main/java/io/github/ssforu/pin4u/features/recommendations/application/AiKeywordServiceImpl.java
+++ b/src/main/java/io/github/ssforu/pin4u/features/recommendations/application/AiKeywordServiceImpl.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -63,8 +64,12 @@ public class AiKeywordServiceImpl implements AiKeywordService {
                     .bodyValue(body)
                     .retrieve()
                     .bodyToMono(Map.class)
-                    .onErrorReturn(null)
-                    .block();
+                    .onErrorResume(e -> {
+                        log.warn("[AI] OpenAI keyword call failed: {}", e.getMessage());
+                        return Mono.empty();
+                    })
+                    .blockOptional()
+                    .orElse(null);
 
             List<String> out = parseKeywords(resp);
             if (out.isEmpty()) return heuristicFallback(message);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,6 +46,16 @@ app:
     image-enabled: false
   summary:
     ttl-days: 7
+  http:
+    kakao-search:
+      connect-timeout: 2s
+      response-timeout: 3s
+    kakao-oauth:
+      connect-timeout: 2s
+      response-timeout: 3s
+    openai:
+      connect-timeout: 2s
+      response-timeout: 20s
   ai:
     enabled: ${APP_AI_ENABLED:true}
     openai:


### PR DESCRIPTION
## 변경 요약

- 전 WebClient 빈에 connect/response 타임아웃 적용 (ReadTimeoutHandler, WriteTimeoutHandler 포함)
- KakaoOAuthClient: 인라인 WebClient 생성 제거, 빈 주입으로 전환
- AiKeywordServiceImpl: onErrorReturn(null) → onErrorResume + Mono.empty()
- application.yml에 app.http.* 타임아웃 프로퍼티 외부화

Closes #32