### PR TITLE
feat: Resilience4j 도입 및 외부 API 서킷브레이커 실제 배선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,11 @@ dependencies {
     // Cloud
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+    // Resilience4j
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
+    implementation 'io.github.resilience4j:resilience4j-micrometer:2.2.0'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+
     // 메모리 캐시(Caffeine)
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'com.github.ben-manes.caffeine:caffeine'

--- a/src/main/java/io/github/ssforu/pin4u/features/places/infra/KakaoSearchAdapterImpl.java
+++ b/src/main/java/io/github/ssforu/pin4u/features/places/infra/KakaoSearchAdapterImpl.java
@@ -1,9 +1,12 @@
 package io.github.ssforu.pin4u.features.places.infra;
 
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
 import io.github.ssforu.pin4u.common.exception.ApiErrorCode;
 import io.github.ssforu.pin4u.common.exception.ApiException;
 import io.github.ssforu.pin4u.features.places.domain.KakaoPayload;
 import io.github.ssforu.pin4u.features.places.domain.KakaoSearchPort;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -13,8 +16,9 @@ import org.springframework.web.reactive.function.client.WebClient;
 import java.math.BigDecimal;
 import java.util.List;
 
+@Slf4j
 @Component
-@ConditionalOnBean(name = "kakaoWebClient") // kakaoWebClient 있을 때만 진짜 어댑터 활성화
+@ConditionalOnBean(name = "kakaoWebClient")
 public class KakaoSearchAdapterImpl implements KakaoSearchPort {
 
     private final WebClient kakao;
@@ -28,7 +32,10 @@ public class KakaoSearchAdapterImpl implements KakaoSearchPort {
         this.enabled = enabled;
     }
 
+    // Retry가 안쪽에서 재시도하고, 재시도 실패가 CircuitBreaker에 기록된다.
     @Override
+    @CircuitBreaker(name = "kakaoSearch", fallbackMethod = "keywordSearchFallback")
+    @Retry(name = "kakaoSearch")
     public List<KakaoPayload.Document> keywordSearch(
             BigDecimal lat, BigDecimal lng, String query, int radiusM, int size
     ) {
@@ -51,5 +58,12 @@ public class KakaoSearchAdapterImpl implements KakaoSearchPort {
             throw new ApiException(ApiErrorCode.UPSTREAM_ERROR, "kakao search failed", null);
         }
         return resp.getBody().documents();
+    }
+
+    @SuppressWarnings("unused")
+    private List<KakaoPayload.Document> keywordSearchFallback(
+            BigDecimal lat, BigDecimal lng, String query, int radiusM, int size, Throwable t) {
+        log.warn("[Kakao] search fallback for query='{}': {}", query, t.getMessage());
+        return List.of();
     }
 }

--- a/src/main/java/io/github/ssforu/pin4u/features/recommendations/application/AiKeywordServiceImpl.java
+++ b/src/main/java/io/github/ssforu/pin4u/features/recommendations/application/AiKeywordServiceImpl.java
@@ -1,6 +1,8 @@
 package io.github.ssforu.pin4u.features.recommendations.application;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -34,6 +36,8 @@ public class AiKeywordServiceImpl implements AiKeywordService {
     }
 
     @Override
+    @CircuitBreaker(name = "openai", fallbackMethod = "extractTop2Fallback")
+    @Retry(name = "openai")
     public List<String> extractTop2(String message) {
         // 비어있으면 휴리스틱 폴백
         if (message == null || message.isBlank() || !aiEnabled) {
@@ -104,6 +108,12 @@ public class AiKeywordServiceImpl implements AiKeywordService {
             }
         } catch (Exception ignore) {}
         return List.of();
+    }
+
+    @SuppressWarnings("unused")
+    private List<String> extractTop2Fallback(String message, Throwable t) {
+        log.warn("[AI] keyword extraction circuit open, falling back to heuristic: {}", t.getMessage());
+        return heuristicFallback(message);
     }
 
     private List<String> heuristicFallback(String msg) {

--- a/src/main/java/io/github/ssforu/pin4u/features/requests/application/AiSummaryServiceImpl.java
+++ b/src/main/java/io/github/ssforu/pin4u/features/requests/application/AiSummaryServiceImpl.java
@@ -1,6 +1,9 @@
 package io.github.ssforu.pin4u.features.requests.application;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.resilience4j.bulkhead.annotation.Bulkhead;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
 import io.github.ssforu.pin4u.features.places.domain.Place;
 import io.github.ssforu.pin4u.features.places.domain.PlaceSummary;
 import io.github.ssforu.pin4u.features.places.infra.PlaceRepository;
@@ -103,7 +106,12 @@ public class AiSummaryServiceImpl implements AiSummaryService {
         log.info("🎉 [AI] Completed summary generation for request: {}", requestSlug);
     }
 
+    // Bulkhead: Hikari pool(30) 대비 AI 동시 호출을 10으로 제한해 커넥션 풀 고갈 방지.
+    // Retry가 안쪽에서 재시도 → 실패가 CircuitBreaker에 기록 → Bulkhead가 동시 호출 상한 관리.
     @Override
+    @Bulkhead(name = "openai")
+    @CircuitBreaker(name = "openai", fallbackMethod = "generateSummaryFallback")
+    @Retry(name = "openai")
     public Optional<String> generateSummary(
             String placeName,
             String categoryName,
@@ -179,5 +187,15 @@ public class AiSummaryServiceImpl implements AiSummaryService {
             log.warn("[AI] summary fail: {}", e.toString());
             return Optional.empty();
         }
+    }
+
+    @SuppressWarnings("unused")
+    private Optional<String> generateSummaryFallback(
+            String placeName, String categoryName,
+            Double rating, Integer ratingCount,
+            List<String> reviewSnippets, List<String> userTags,
+            Throwable t) {
+        log.warn("[AI] summary circuit open for place='{}': {}", placeName, t.getMessage());
+        return Optional.empty();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,26 +67,32 @@ server:
   forward-headers-strategy: framework
 
 resilience4j:
+  circuitbreaker:
+    instances:
+      kakaoSearch:
+        sliding-window-type: COUNT_BASED
+        sliding-window-size: 20          # 최근 20회 호출 기준으로 실패율 계산
+        failure-rate-threshold: 50       # 50% 실패 시 OPEN
+        wait-duration-in-open-state: 30s # OPEN 후 30초 대기 후 HALF_OPEN 전이
+        permitted-number-of-calls-in-half-open-state: 5
+      openai:
+        sliding-window-type: COUNT_BASED
+        sliding-window-size: 10          # AI 호출은 빈도가 낮으므로 작은 윈도우
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 60s # OpenAI 장애는 복구에 시간 소요
+        permitted-number-of-calls-in-half-open-state: 3
   retry:
     instances:
       kakaoSearch:
         max-attempts: 3
         wait-duration: 300ms
-  timelimiter:
+      openai:
+        max-attempts: 2
+        wait-duration: 1s
+  bulkhead:
     instances:
-      kakaoSearch:
-        timeout-duration: 2s
-  circuitbreaker:
-    instances:
-      kakaoSearch:
-        sliding-window-type: COUNT_BASED
-        sliding-window-size: 20
-        failure-rate-threshold: 50
-  ratelimiter:
-    instances:
-      kakaoSearch:
-        limit-for-period: 10
-        limit-refresh-period: 1s
+      openai:
+        max-concurrent-calls: 10         # Hikari pool(30) 대비 AI 동시 호출 제한
 
 management:
   server:
@@ -94,9 +100,12 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,metrics,prometheus
+        include: health,info,metrics,prometheus,circuitbreakers,circuitbreakerevents
   endpoint:
     health:
       show-details: when-authorized
     prometheus:
+      enabled: true
+  health:
+    circuitbreakers:
       enabled: true


### PR DESCRIPTION
## 변경 요약

- resilience4j-spring-boot3 2.2.0 의존성 추가
- kakaoSearch / openai 인스턴스별 CircuitBreaker + Retry 설정
- KakaoSearchAdapterImpl, AiKeywordServiceImpl, AiSummaryServiceImpl에 애노테이션 배선
- 각 서비스에 fallback 메서드 구현 (빈 리스트 / heuristic / empty)
- Actuator에 circuitbreakers 엔드포인트 노출

Closes #34