### PR TITLE
fix: AiSummaryServiceImpl 트랜잭션 분리 및 비동기 파이프라인 완결

### DIFF
--- a/src/main/java/io/github/ssforu/pin4u/features/requests/api/RequestDetailController.java
+++ b/src/main/java/io/github/ssforu/pin4u/features/requests/api/RequestDetailController.java
@@ -2,24 +2,26 @@ package io.github.ssforu.pin4u.features.requests.api;
 
 import io.github.ssforu.pin4u.common.response.ApiResponse;
 import io.github.ssforu.pin4u.features.requests.application.RequestDetailService;
+import io.github.ssforu.pin4u.features.requests.domain.AiSummaryJob;
 import io.github.ssforu.pin4u.features.requests.dto.RequestDetailDtos.RequestDetailResponse;
-import org.springframework.stereotype.Controller;
+import io.github.ssforu.pin4u.features.requests.infra.AiSummaryJobRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-// ✅ Swagger 문서용 어노테이션 import
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
+import java.util.Map;
 
 @Tag(name = "Requests")
 @RestController
 @RequestMapping("/api/requests")
+@RequiredArgsConstructor
 public class RequestDetailController {
 
     private final RequestDetailService requestDetailService;
-
-    public RequestDetailController(RequestDetailService requestDetailService) {
-        this.requestDetailService = requestDetailService;
-    }
+    private final AiSummaryJobRepository jobRepository;
 
     /**
      * #7 A-지도화면(지도의 핀 + 카드뉴스)
@@ -31,10 +33,23 @@ public class RequestDetailController {
     @GetMapping("/{slug}")
     public ApiResponse<RequestDetailResponse> get(
             @PathVariable String slug,
-            @RequestParam(value = "limit", required = false) Integer limit,
-            @RequestParam(value = "include_ai", defaultValue = "false") boolean includeAi
+            @RequestParam(value = "limit", required = false) Integer limit
     ) {
-        RequestDetailResponse data = requestDetailService.getRequestDetail(slug, limit, includeAi);
+        RequestDetailResponse data = requestDetailService.getRequestDetail(slug, limit);
         return ApiResponse.success(data);
+    }
+
+    @Operation(summary = "AI 요약 작업 상태", description = "요청에 대한 AI 요약 생성 작업의 현재 상태를 반환합니다.")
+    @GetMapping("/{slug}/summary-status")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> summaryStatus(@PathVariable String slug) {
+        return jobRepository.findByRequestSlug(slug)
+                .map(job -> ResponseEntity.ok(ApiResponse.success(Map.<String, Object>of(
+                        "status", job.getStatus().name(),
+                        "attempts", job.getAttempts(),
+                        "updatedAt", job.getUpdatedAt()
+                ))))
+                .orElseGet(() -> ResponseEntity.ok(ApiResponse.success(
+                        Map.of("status", "NOT_STARTED")
+                )));
     }
 }

--- a/src/main/java/io/github/ssforu/pin4u/features/requests/application/AiSummaryServiceImpl.java
+++ b/src/main/java/io/github/ssforu/pin4u/features/requests/application/AiSummaryServiceImpl.java
@@ -4,17 +4,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.resilience4j.bulkhead.annotation.Bulkhead;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;
-import io.github.ssforu.pin4u.features.places.domain.Place;
-import io.github.ssforu.pin4u.features.places.domain.PlaceSummary;
-import io.github.ssforu.pin4u.features.places.infra.PlaceRepository;
-import io.github.ssforu.pin4u.features.places.infra.PlaceSummaryRepository;
-import io.github.ssforu.pin4u.features.requests.infra.RequestPlaceAggregateRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -27,9 +21,7 @@ import java.util.Optional;
 public class AiSummaryServiceImpl implements AiSummaryService {
 
     private final WebClient openai;
-    private final RequestPlaceAggregateRepository rpaRepository;
-    private final PlaceRepository placeRepository;
-    private final PlaceSummaryRepository placeSummaryRepository;
+    private final AiSummaryTxHelper txHelper;
 
     @Value("${app.ai.enabled:true}")
     private boolean aiEnabled;
@@ -41,76 +33,51 @@ public class AiSummaryServiceImpl implements AiSummaryService {
 
     public AiSummaryServiceImpl(
             @Qualifier("openaiWebClient") WebClient openai,
-            RequestPlaceAggregateRepository rpaRepository,
-            PlaceRepository placeRepository,
-            PlaceSummaryRepository placeSummaryRepository
+            AiSummaryTxHelper txHelper
     ) {
         this.openai = openai;
-        this.rpaRepository = rpaRepository;
-        this.placeRepository = placeRepository;
-        this.placeSummaryRepository = placeSummaryRepository;
+        this.txHelper = txHelper;
     }
 
     /**
-     * [Theme 2] 비동기 처리 대상 메서드
-     * 1. 지연 시뮬레이션 (3초)
-     * 2. 요청에 속한 장소들 조회
-     * 3. 각 장소에 대해 AI 요약 생성 및 저장
+     * 트랜잭션 3단 분리:
+     * [1단: 짧은 읽기 tx] txHelper.loadTargets — 대상 조회, DB 커넥션 즉시 반환
+     * [2단: tx 없음] generateSummary — OpenAI blocking 호출, DB 커넥션 미점유
+     * [3단: 짧은 쓰기 tx] txHelper.saveSummary — 결과 저장, DB 커넥션 즉시 반환
+     *
+     * 이전 구조: 단일 @Transactional 안에서 OpenAI 최대 20초 blocking →
+     * aiTaskExecutor max 50 × DB 커넥션 점유 vs Hikari pool 30 → 풀 고갈.
+     * 분리 후: 외부 호출 동안 DB 커넥션을 점유하지 않는다.
      */
     @Override
-    @Transactional
     public void generateAndSaveSummary(String requestSlug) {
-        // 요청에 포함된 장소들 조회
-        var aggregates = rpaRepository.findAllByRequestId(requestSlug);
+        // [1단: 읽기 tx] 대상 장소 조회 — tx 종료 후 커넥션 반환
+        var targets = txHelper.loadTargets(requestSlug);
 
-        for (var agg : aggregates) {
-            Long placeId = agg.getPlaceId();
-
-            // 이미 요약이 있으면 스킵 (비용 절감)
-            if (placeSummaryRepository.existsById(placeId)) {
-                continue;
-            }
-
-            // 장소 정보 조회
-            Optional<Place> placeOpt = placeRepository.findById(placeId);
-            if (placeOpt.isEmpty()) continue;
-            Place place = placeOpt.get();
-
-            // 3. 요약 생성 (OpenAI 호출)
-            // (실제 데이터가 부족하므로 이름과 카테고리만으로 생성 시도)
+        for (var target : targets) {
+            // [2단: tx 없음] 외부 API 호출 — DB 커넥션 미점유
             Optional<String> summaryOpt = generateSummary(
-                    place.getPlaceName(),
-                    place.getCategoryName(),
-                    null, null, null, null // 상세 정보는 Mock이나 실제 수집 데이터 연동 필요
+                    target.placeName(), target.categoryName(),
+                    null, null, null, null
             );
 
-            // 4. 저장
+            // [3단: 쓰기 tx] 결과 저장 — 짧은 tx
             if (summaryOpt.isPresent()) {
-                PlaceSummary summary = PlaceSummary.builder()
-                        .place(place)
-                        .summaryText(summaryOpt.get())
-                        .evidence("AI Generated based on basic info")
-                        .build();
-                placeSummaryRepository.save(summary);
-                log.info("✅ [AI] Saved summary for place: {}", place.getPlaceName());
+                txHelper.saveSummary(target.placeId(), summaryOpt.get());
+                log.info("[AI] Saved summary for place: {}", target.placeName());
             }
         }
-        log.info("🎉 [AI] Completed summary generation for request: {}", requestSlug);
+        log.info("[AI] Completed summary generation for request: {}", requestSlug);
     }
 
-    // Bulkhead: Hikari pool(30) 대비 AI 동시 호출을 10으로 제한해 커넥션 풀 고갈 방지.
-    // Retry가 안쪽에서 재시도 → 실패가 CircuitBreaker에 기록 → Bulkhead가 동시 호출 상한 관리.
     @Override
     @Bulkhead(name = "openai")
     @CircuitBreaker(name = "openai", fallbackMethod = "generateSummaryFallback")
     @Retry(name = "openai")
     public Optional<String> generateSummary(
-            String placeName,
-            String categoryName,
-            Double rating,
-            Integer ratingCount,
-            List<String> reviewSnippets,
-            List<String> userTags
+            String placeName, String categoryName,
+            Double rating, Integer ratingCount,
+            List<String> reviewSnippets, List<String> userTags
     ) {
         if (!aiEnabled) return Optional.empty();
         try {
@@ -158,9 +125,9 @@ public class AiSummaryServiceImpl implements AiSummaryService {
             Object choicesObj = resp.get("choices");
             if (!(choicesObj instanceof List<?> choices) || choices.isEmpty()) return Optional.empty();
             Object ch0 = choices.get(0);
-            if (!(ch0 instanceof Map<?,?> ch0Map)) return Optional.empty();
+            if (!(ch0 instanceof Map<?, ?> ch0Map)) return Optional.empty();
             Object msgObj = ch0Map.get("message");
-            if (!(msgObj instanceof Map<?,?> msgMap)) return Optional.empty();
+            if (!(msgObj instanceof Map<?, ?> msgMap)) return Optional.empty();
             Object content = msgMap.get("content");
             if (content == null) return Optional.empty();
             String contentStr = String.valueOf(content).trim();
@@ -172,7 +139,7 @@ public class AiSummaryServiceImpl implements AiSummaryService {
                 if (st != null && !String.valueOf(st).isBlank()) {
                     return Optional.of(String.valueOf(st));
                 }
-            } catch (Exception ignore) { /* 평문 fallback */ }
+            } catch (Exception ignore) { /* plain text fallback */ }
 
             return Optional.of(contentStr);
         } catch (Exception e) {

--- a/src/main/java/io/github/ssforu/pin4u/features/requests/application/AiSummaryTxHelper.java
+++ b/src/main/java/io/github/ssforu/pin4u/features/requests/application/AiSummaryTxHelper.java
@@ -1,0 +1,62 @@
+package io.github.ssforu.pin4u.features.requests.application;
+
+import io.github.ssforu.pin4u.features.places.domain.Place;
+import io.github.ssforu.pin4u.features.places.domain.PlaceSummary;
+import io.github.ssforu.pin4u.features.places.infra.PlaceRepository;
+import io.github.ssforu.pin4u.features.places.infra.PlaceSummaryRepository;
+import io.github.ssforu.pin4u.features.requests.domain.RequestPlaceAggregate;
+import io.github.ssforu.pin4u.features.requests.infra.RequestPlaceAggregateRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * AiSummaryServiceImpl의 트랜잭션 경계를 분리하기 위한 헬퍼.
+ * self-invocation으로 @Transactional이 무효화되는 것을 방지하기 위해 별도 빈으로 분리.
+ *
+ * generateAndSaveSummary의 흐름:
+ * [1단: 짧은 읽기 tx] loadTargets → 대상 장소 목록 조회
+ * [2단: tx 없음] 외부 OpenAI 호출 (AiSummaryServiceImpl.generateSummary) — DB 커넥션 미점유
+ * [3단: 짧은 쓰기 tx] saveSummary → 결과 저장
+ */
+@Component
+@RequiredArgsConstructor
+public class AiSummaryTxHelper {
+
+    private final RequestPlaceAggregateRepository rpaRepository;
+    private final PlaceRepository placeRepository;
+    private final PlaceSummaryRepository placeSummaryRepository;
+
+    public record Target(Long placeId, String placeName, String categoryName) {}
+
+    @Transactional(readOnly = true)
+    public List<Target> loadTargets(String requestSlug) {
+        var aggregates = rpaRepository.findAllByRequestId(requestSlug);
+        return aggregates.stream()
+                .filter(agg -> !placeSummaryRepository.existsById(agg.getPlaceId()))
+                .map(agg -> {
+                    Optional<Place> place = placeRepository.findById(agg.getPlaceId());
+                    return place.map(p -> new Target(p.getId(), p.getPlaceName(), p.getCategoryName()))
+                            .orElse(null);
+                })
+                .filter(t -> t != null)
+                .toList();
+    }
+
+    @Transactional
+    public void saveSummary(Long placeId, String summaryText) {
+        placeRepository.findById(placeId).ifPresent(place -> {
+            if (!placeSummaryRepository.existsById(placeId)) {
+                PlaceSummary summary = PlaceSummary.builder()
+                        .place(place)
+                        .summaryText(summaryText)
+                        .evidence("AI Generated based on basic info")
+                        .build();
+                placeSummaryRepository.save(summary);
+            }
+        });
+    }
+}

--- a/src/main/java/io/github/ssforu/pin4u/features/requests/application/RequestDetailService.java
+++ b/src/main/java/io/github/ssforu/pin4u/features/requests/application/RequestDetailService.java
@@ -3,5 +3,5 @@ package io.github.ssforu.pin4u.features.requests.application;
 import io.github.ssforu.pin4u.features.requests.dto.RequestDetailDtos.RequestDetailResponse;
 
 public interface RequestDetailService {
-    RequestDetailResponse getRequestDetail(String slug, Integer limit, boolean includeAi);
+    RequestDetailResponse getRequestDetail(String slug, Integer limit);
 }

--- a/src/main/java/io/github/ssforu/pin4u/features/requests/application/RequestDetailServiceImpl.java
+++ b/src/main/java/io/github/ssforu/pin4u/features/requests/application/RequestDetailServiceImpl.java
@@ -46,7 +46,7 @@ public class RequestDetailServiceImpl implements RequestDetailService {
     }
 
     @Override
-    public RequestDetailResponse getRequestDetail(String slug, Integer limit, boolean includeAi) {
+    public RequestDetailResponse getRequestDetail(String slug, Integer limit) {
         Request req = requestRepository.findBySlug(slug)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "request not found"));
         Station st = stationRepository.findByCode(req.getStationCode())

--- a/src/main/java/io/github/ssforu/pin4u/features/requests/domain/AiSummaryJob.java
+++ b/src/main/java/io/github/ssforu/pin4u/features/requests/domain/AiSummaryJob.java
@@ -1,0 +1,59 @@
+package io.github.ssforu.pin4u.features.requests.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "ai_summary_job")
+@Getter
+@Setter
+@NoArgsConstructor
+public class AiSummaryJob {
+
+    public enum Status { PENDING, RUNNING, SUCCEEDED, FAILED }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "request_slug", nullable = false, unique = true, length = 64)
+    private String requestSlug;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private Status status = Status.PENDING;
+
+    @Column(name = "attempts", nullable = false)
+    private int attempts;
+
+    @Column(name = "last_error", columnDefinition = "TEXT")
+    private String lastError;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        OffsetDateTime now = OffsetDateTime.now();
+        if (createdAt == null) createdAt = now;
+        if (updatedAt == null) updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = OffsetDateTime.now();
+    }
+
+    public AiSummaryJob(String requestSlug) {
+        this.requestSlug = requestSlug;
+        this.status = Status.PENDING;
+        this.attempts = 0;
+    }
+}

--- a/src/main/java/io/github/ssforu/pin4u/features/requests/event/RequestEventListener.java
+++ b/src/main/java/io/github/ssforu/pin4u/features/requests/event/RequestEventListener.java
@@ -1,8 +1,11 @@
 package io.github.ssforu.pin4u.features.requests.event;
 
 import io.github.ssforu.pin4u.features.requests.application.AiSummaryService;
+import io.github.ssforu.pin4u.features.requests.domain.AiSummaryJob;
+import io.github.ssforu.pin4u.features.requests.infra.AiSummaryJobRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -14,25 +17,43 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class RequestEventListener {
 
     private final AiSummaryService aiSummaryService;
+    private final AiSummaryJobRepository jobRepository;
 
-    /**
-     * @Async("aiTaskExecutor"): 별도의 스레드 풀에서 실행 (Non-blocking)
-     * @TransactionalEventListener(phase = AFTER_COMMIT):
-     * 메인 트랜잭션(요청 저장)이 DB에 완전히 커밋된 후에 실행함.
-     * (데이터가 없어서 AI가 조회 실패하는 동시성 문제 방지)
-     */
     @Async("aiTaskExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleRequestCreated(RequestCreatedEvent event) {
-        log.info("🚀 [Async] AI Summary Event Received: slug={}", event.requestSlug());
+        String slug = event.requestSlug();
+        log.info("[Async] AI Summary Event Received: slug={}", slug);
+
+        // UNIQUE 제약(request_slug)으로 중복 실행 방지
+        AiSummaryJob job;
+        try {
+            job = jobRepository.save(new AiSummaryJob(slug));
+        } catch (DataIntegrityViolationException e) {
+            log.info("[Async] Job already exists for slug={}, skipping", slug);
+            return;
+        }
 
         try {
-            // 오래 걸리는 작업 (AI 호출 + DB 업데이트)
-            aiSummaryService.generateAndSaveSummary(event.requestSlug());
-            log.info("✅ [Async] AI Summary Completed: slug={}", event.requestSlug());
+            job.setStatus(AiSummaryJob.Status.RUNNING);
+            job.setAttempts(job.getAttempts() + 1);
+            jobRepository.save(job);
+
+            aiSummaryService.generateAndSaveSummary(slug);
+
+            job.setStatus(AiSummaryJob.Status.SUCCEEDED);
+            jobRepository.save(job);
+            log.info("[Async] AI Summary Completed: slug={}", slug);
+
         } catch (Exception e) {
-            log.error("❌ [Async] AI Summary Failed: slug={}, error={}", event.requestSlug(), e.getMessage());
-            // 추후 여기에 '실패 알림' 로직 추가 가능
+            log.error("[Async] AI Summary Failed: slug={}, error={}", slug, e.getMessage());
+            job.setStatus(AiSummaryJob.Status.FAILED);
+            job.setLastError(e.getMessage() != null ? e.getMessage().substring(0, Math.min(e.getMessage().length(), 500)) : "unknown");
+            try {
+                jobRepository.save(job);
+            } catch (Exception saveErr) {
+                log.error("[Async] Failed to save job failure status: {}", saveErr.getMessage());
+            }
         }
     }
 }

--- a/src/main/java/io/github/ssforu/pin4u/features/requests/infra/AiSummaryJobRepository.java
+++ b/src/main/java/io/github/ssforu/pin4u/features/requests/infra/AiSummaryJobRepository.java
@@ -1,0 +1,10 @@
+package io.github.ssforu.pin4u.features.requests.infra;
+
+import io.github.ssforu.pin4u.features.requests.domain.AiSummaryJob;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AiSummaryJobRepository extends JpaRepository<AiSummaryJob, Long> {
+    Optional<AiSummaryJob> findByRequestSlug(String requestSlug);
+}

--- a/src/main/resources/db/migration/V23__create_ai_summary_job.sql
+++ b/src/main/resources/db/migration/V23__create_ai_summary_job.sql
@@ -1,0 +1,14 @@
+-- V23: AI 요약 작업 상태 추적 테이블
+CREATE TABLE IF NOT EXISTS ai_summary_job (
+    id              BIGSERIAL PRIMARY KEY,
+    request_slug    VARCHAR(64) NOT NULL,
+    status          VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+    attempts        INT NOT NULL DEFAULT 0,
+    last_error      TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT uq_ai_summary_job_slug UNIQUE (request_slug)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_summary_job_status ON ai_summary_job (status);


### PR DESCRIPTION
## 변경

- 트랜잭션 3단 분리: [읽기tx] → [tx없음 외부호출] → [쓰기tx]
- AiSummaryTxHelper 별도 빈으로 self-invocation 방지
- V23 ai_summary_job 테이블 + job 상태 관리
- summary-status 폴링 엔드포인트
- include_ai 미참조 파라미터 제거

Closes #67