### PR TITLE
fix: DoD 요구 테스트 전량 작성 (8→29건)

### DIFF
--- a/src/test/java/io/github/ssforu/pin4u/common/ReadOnlyTransactionAuditTest.java
+++ b/src/test/java/io/github/ssforu/pin4u/common/ReadOnlyTransactionAuditTest.java
@@ -1,0 +1,39 @@
+package io.github.ssforu.pin4u.common;
+
+import io.github.ssforu.pin4u.features.groups.application.GroupMapService;
+import io.github.ssforu.pin4u.features.home.application.HomeService;
+import io.github.ssforu.pin4u.features.requests.application.RequestDetailServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * readOnly=true 메서드가 실제로 readOnly로 선언되어 있는지 반사적으로 검증.
+ * 이슈 5(#36) 조치 이후 회귀 방지.
+ */
+class ReadOnlyTransactionAuditTest {
+
+    @Test
+    void requestDetailServiceImpl_classLevel_isReadOnly() {
+        Transactional tx = RequestDetailServiceImpl.class.getAnnotation(Transactional.class);
+        assertThat(tx).isNotNull();
+        assertThat(tx.readOnly()).isTrue();
+    }
+
+    @Test
+    void homeService_dashboard_isReadOnly() throws Exception {
+        Transactional tx = HomeService.class.getMethod("dashboard", Long.class).getAnnotation(Transactional.class);
+        assertThat(tx).isNotNull();
+        assertThat(tx.readOnly()).isTrue();
+    }
+
+    @Test
+    void groupMapService_getGroupMap_isReadOnly() throws Exception {
+        Transactional tx = GroupMapService.class
+                .getMethod("getGroupMapAsRequestDetail", String.class, Long.class, Integer.class)
+                .getAnnotation(Transactional.class);
+        assertThat(tx).isNotNull();
+        assertThat(tx.readOnly()).isTrue();
+    }
+}

--- a/src/test/java/io/github/ssforu/pin4u/common/Resilience4jAnnotationAuditTest.java
+++ b/src/test/java/io/github/ssforu/pin4u/common/Resilience4jAnnotationAuditTest.java
@@ -1,0 +1,62 @@
+package io.github.ssforu.pin4u.common;
+
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.ssforu.pin4u.features.places.infra.KakaoSearchAdapterImpl;
+import io.github.ssforu.pin4u.features.recommendations.application.AiKeywordServiceImpl;
+import io.github.ssforu.pin4u.features.requests.application.AiSummaryServiceImpl;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Resilience4j 애노테이션의 fallback 메서드 시그니처가 올바른지 검증.
+ * 원본 메서드 파라미터 + Throwable이 마지막이어야 런타임에 정상 동작.
+ */
+class Resilience4jAnnotationAuditTest {
+
+    @Test
+    void kakaoSearchFallback_signatureMatchesOriginal() {
+        assertFallbackSignature(KakaoSearchAdapterImpl.class, "keywordSearch", "keywordSearchFallback");
+    }
+
+    @Test
+    void aiKeywordFallback_signatureMatchesOriginal() {
+        assertFallbackSignature(AiKeywordServiceImpl.class, "extractTop2", "extractTop2Fallback");
+    }
+
+    @Test
+    void aiSummaryFallback_signatureMatchesOriginal() {
+        assertFallbackSignature(AiSummaryServiceImpl.class, "generateSummary", "generateSummaryFallback");
+    }
+
+    private void assertFallbackSignature(Class<?> clazz, String originalName, String fallbackName) {
+        Method original = Arrays.stream(clazz.getMethods())
+                .filter(m -> m.getName().equals(originalName))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Original method not found: " + originalName));
+
+        // @CircuitBreaker에 fallbackMethod가 선언되어 있는지
+        CircuitBreaker cbAnnotation = original.getAnnotation(CircuitBreaker.class);
+        assertThat(cbAnnotation).isNotNull();
+        assertThat(cbAnnotation.fallbackMethod()).isEqualTo(fallbackName);
+
+        // fallback 메서드가 존재하고, 마지막 파라미터가 Throwable인지
+        Method fallback = Arrays.stream(clazz.getDeclaredMethods())
+                .filter(m -> m.getName().equals(fallbackName))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Fallback method not found: " + fallbackName));
+
+        Class<?>[] fbParams = fallback.getParameterTypes();
+        assertThat(fbParams.length).isGreaterThan(0);
+        assertThat(fbParams[fbParams.length - 1])
+                .as("Fallback's last param must be Throwable")
+                .isEqualTo(Throwable.class);
+
+        // 원본 파라미터 + Throwable = fallback 파라미터
+        Class<?>[] origParams = original.getParameterTypes();
+        assertThat(fbParams.length).isEqualTo(origParams.length + 1);
+    }
+}

--- a/src/test/java/io/github/ssforu/pin4u/common/resolver/LoginUserArgumentResolverTest.java
+++ b/src/test/java/io/github/ssforu/pin4u/common/resolver/LoginUserArgumentResolverTest.java
@@ -1,0 +1,127 @@
+package io.github.ssforu.pin4u.common.resolver;
+
+import io.github.ssforu.pin4u.common.annotation.LoginUser;
+import io.github.ssforu.pin4u.common.auth.AuthTokenProvider;
+import io.github.ssforu.pin4u.features.member.infra.UserRepository;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+class LoginUserArgumentResolverTest {
+
+    private static final String SECRET = "test-secret-that-is-at-least-32-characters-long";
+    private AuthTokenProvider tokenProvider;
+    private LoginUserArgumentResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        tokenProvider = new AuthTokenProvider(SECRET);
+        UserRepository userRepo = mock(UserRepository.class);
+        resolver = new LoginUserArgumentResolver(userRepo, tokenProvider);
+    }
+
+    // 테스트용 메서드 시그니처
+    void requiredEndpoint(@LoginUser(required = true) Long userId) {}
+    void optionalEndpoint(@LoginUser(required = false) Long userId) {}
+
+    private MethodParameter paramOf(String methodName) throws Exception {
+        Method m = getClass().getDeclaredMethod(methodName, Long.class);
+        return new MethodParameter(m, 0);
+    }
+
+    @Test
+    void validSignedToken_returnsUid() throws Exception {
+        String token = tokenProvider.issueToken(42L);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("uid", token));
+        NativeWebRequest webRequest = new ServletWebRequest(request);
+
+        Object result = resolver.resolveArgument(paramOf("requiredEndpoint"), null, webRequest, null);
+
+        assertThat(result).isEqualTo(42L);
+    }
+
+    @Test
+    void forgedPlainUid_required_returns401() throws Exception {
+        // 평문 uid=1 쿠키 위조 → 401
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("uid", "1"));
+        NativeWebRequest webRequest = new ServletWebRequest(request);
+
+        assertThatThrownBy(() ->
+                resolver.resolveArgument(paramOf("requiredEndpoint"), null, webRequest, null))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("login_required");
+    }
+
+    @Test
+    void tamperedSignature_required_returns401() throws Exception {
+        String token = tokenProvider.issueToken(42L);
+        String tampered = token.substring(0, token.lastIndexOf('.') + 1) + "0000000000";
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("uid", tampered));
+        NativeWebRequest webRequest = new ServletWebRequest(request);
+
+        assertThatThrownBy(() ->
+                resolver.resolveArgument(paramOf("requiredEndpoint"), null, webRequest, null))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("login_required");
+    }
+
+    @Test
+    void differentSecretToken_rejected() throws Exception {
+        AuthTokenProvider otherProvider = new AuthTokenProvider("another-secret-that-is-at-least-32-chars!!");
+        String otherToken = otherProvider.issueToken(42L);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("uid", otherToken));
+        NativeWebRequest webRequest = new ServletWebRequest(request);
+
+        assertThatThrownBy(() ->
+                resolver.resolveArgument(paramOf("requiredEndpoint"), null, webRequest, null))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("login_required");
+    }
+
+    @Test
+    void noCookie_required_returns401() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        NativeWebRequest webRequest = new ServletWebRequest(request);
+
+        assertThatThrownBy(() ->
+                resolver.resolveArgument(paramOf("requiredEndpoint"), null, webRequest, null))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("login_required");
+    }
+
+    @Test
+    void noCookie_optional_returnsNull() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        NativeWebRequest webRequest = new ServletWebRequest(request);
+
+        Object result = resolver.resolveArgument(paramOf("optionalEndpoint"), null, webRequest, null);
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void forgedPlainUid_optional_returnsNull() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("uid", "99"));
+        NativeWebRequest webRequest = new ServletWebRequest(request);
+
+        Object result = resolver.resolveArgument(paramOf("optionalEndpoint"), null, webRequest, null);
+
+        assertThat(result).isNull();
+    }
+}

--- a/src/test/java/io/github/ssforu/pin4u/features/requests/application/AiSummaryServiceTransactionTest.java
+++ b/src/test/java/io/github/ssforu/pin4u/features/requests/application/AiSummaryServiceTransactionTest.java
@@ -1,0 +1,45 @@
+package io.github.ssforu.pin4u.features.requests.application;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * AiSummaryServiceImpl.generateAndSaveSummary에 @Transactional이 없음을 검증.
+ * 외부 API 호출이 트랜잭션 밖에서 실행되어야 커넥션 풀 고갈을 방지한다.
+ * 트랜잭션은 AiSummaryTxHelper의 loadTargets(readOnly)/saveSummary(write)에 위임.
+ */
+class AiSummaryServiceTransactionTest {
+
+    @Test
+    void generateAndSaveSummary_hasNoTransactionalAnnotation() throws Exception {
+        Method method = AiSummaryServiceImpl.class.getMethod("generateAndSaveSummary", String.class);
+        Transactional txAnnotation = method.getAnnotation(Transactional.class);
+
+        assertThat(txAnnotation)
+                .as("generateAndSaveSummary must NOT have @Transactional — " +
+                        "external API calls must run outside transaction to prevent connection pool exhaustion")
+                .isNull();
+    }
+
+    @Test
+    void txHelper_loadTargets_isReadOnly() throws Exception {
+        Method method = AiSummaryTxHelper.class.getMethod("loadTargets", String.class);
+        Transactional tx = method.getAnnotation(Transactional.class);
+
+        assertThat(tx).isNotNull();
+        assertThat(tx.readOnly()).isTrue();
+    }
+
+    @Test
+    void txHelper_saveSummary_isWriteTransaction() throws Exception {
+        Method method = AiSummaryTxHelper.class.getMethod("saveSummary", Long.class, String.class);
+        Transactional tx = method.getAnnotation(Transactional.class);
+
+        assertThat(tx).isNotNull();
+        assertThat(tx.readOnly()).isFalse();
+    }
+}

--- a/src/test/java/io/github/ssforu/pin4u/features/stations/application/StationServiceCacheKeyTest.java
+++ b/src/test/java/io/github/ssforu/pin4u/features/stations/application/StationServiceCacheKeyTest.java
@@ -1,0 +1,40 @@
+package io.github.ssforu.pin4u.features.stations.application;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * StationServiceImpl.normalizeKey의 캐시 키 정규화 단위 테스트.
+ * "강남"과 " 강남 "이 같은 캐시 키를 생성하는지 검증.
+ */
+class StationServiceCacheKeyTest {
+
+    @Test
+    void normalizeKey_trims() {
+        assertThat(StationServiceImpl.normalizeKey(" 강남 ")).isEqualTo("강남");
+    }
+
+    @Test
+    void normalizeKey_lowercases() {
+        assertThat(StationServiceImpl.normalizeKey("Gangnam")).isEqualTo("gangnam");
+    }
+
+    @Test
+    void normalizeKey_trimAndLowercase() {
+        assertThat(StationServiceImpl.normalizeKey("  강남역  ")).isEqualTo("강남역");
+    }
+
+    @Test
+    void normalizeKey_sameQuery_sameKey() {
+        String key1 = StationServiceImpl.normalizeKey("강남");
+        String key2 = StationServiceImpl.normalizeKey(" 강남 ");
+        String key3 = StationServiceImpl.normalizeKey("  강남");
+        assertThat(key1).isEqualTo(key2).isEqualTo(key3);
+    }
+
+    @Test
+    void normalizeKey_null_returnsEmpty() {
+        assertThat(StationServiceImpl.normalizeKey(null)).isEqualTo("");
+    }
+}


### PR DESCRIPTION
## 변경
테스트 8건 → 29건. 위조 쿠키 401, readOnly 회귀 방지, CB fallback 시그니처,
트랜잭션 분리 검증, 캐시 키 정규화 등 구체적 값 단언.

Closes #71