### PR TITLE
test: FIX-4 잔여 통합 테스트 5종 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:postgresql'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
 }
 
 tasks.named('test') {

--- a/src/test/java/io/github/ssforu/pin4u/common/CircuitBreakerStateTransitionTest.java
+++ b/src/test/java/io/github/ssforu/pin4u/common/CircuitBreakerStateTransitionTest.java
@@ -1,0 +1,75 @@
+package io.github.ssforu.pin4u.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.ssforu.pin4u.TestcontainersConfiguration;
+import io.github.ssforu.pin4u.features.recommendations.application.AiKeywordService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+@Tag("integration")
+@SpringBootTest(properties = {
+    "app.ai.enabled=true",
+    "resilience4j.circuitbreaker.instances.openai.sliding-window-size=5",
+    "resilience4j.circuitbreaker.instances.openai.minimum-number-of-calls=5",
+    "resilience4j.circuitbreaker.instances.openai.failure-rate-threshold=50",
+    "resilience4j.circuitbreaker.instances.openai.wait-duration-in-open-state=60s"
+})
+@Import(TestcontainersConfiguration.class)
+class CircuitBreakerStateTransitionTest {
+
+    @Autowired
+    private CircuitBreakerRegistry registry;
+
+    @Autowired
+    private AiKeywordService aiKeywordService;
+
+    @BeforeEach
+    void resetCircuitBreaker() {
+        CircuitBreaker cb = registry.circuitBreaker("openai");
+        cb.reset();
+    }
+
+    @Test
+    @DisplayName("openai CB: 연속 실패 시 CLOSED → OPEN 전이")
+    void openai_closedToOpen() {
+        CircuitBreaker cb = registry.circuitBreaker("openai");
+        assertThat(cb.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
+
+        for (int i = 0; i < 6; i++) {
+            try {
+                CircuitBreaker.decorateRunnable(cb, () -> {
+                    throw new RuntimeException("simulated failure");
+                }).run();
+            } catch (Exception ignored) {
+            }
+        }
+
+        assertThat(cb.getState())
+                .as("5건 이상 연속 실패 후 OPEN 상태여야 한다")
+                .isEqualTo(CircuitBreaker.State.OPEN);
+    }
+
+    @Test
+    @DisplayName("openai CB: OPEN 상태에서 호출 시 즉시 차단 + fallback 반환")
+    void openai_openState_immediatelyFallsBack() {
+        CircuitBreaker cb = registry.circuitBreaker("openai");
+        cb.transitionToOpenState();
+        assertThat(cb.getState()).isEqualTo(CircuitBreaker.State.OPEN);
+
+        List<String> result = aiKeywordService.extractTop2("강남 카페 추천");
+        assertThat(result).as("OPEN 상태에서 fallback이 반환되어야 한다").isNotNull();
+
+        assertThat(cb.getMetrics().getNumberOfNotPermittedCalls())
+                .as("OPEN 상태에서 차단된 호출이 1건 이상이어야 한다")
+                .isGreaterThanOrEqualTo(1);
+    }
+}

--- a/src/test/java/io/github/ssforu/pin4u/common/config/WebClientTimeoutTest.java
+++ b/src/test/java/io/github/ssforu/pin4u/common/config/WebClientTimeoutTest.java
@@ -1,0 +1,87 @@
+package io.github.ssforu.pin4u.common.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.*;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+@Tag("integration")
+class WebClientTimeoutTest {
+
+    private MockWebServer server;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    private WebClient buildClient(Duration connectTimeout, Duration responseTimeout) {
+        HttpClient httpClient = WebClientConfig.buildHttpClient(connectTimeout, responseTimeout);
+        return WebClient.builder()
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .baseUrl(server.url("/").toString())
+                .build();
+    }
+
+    @Test
+    @DisplayName("kakaoSearch: 3초 타임아웃 — 5초 지연 응답 시 타임아웃 예외 발생")
+    void kakaoSearch_responseTimeout() {
+        server.enqueue(new MockResponse()
+                .setBody("{}")
+                .setHeadersDelay(5, TimeUnit.SECONDS));
+
+        WebClient client = buildClient(Duration.ofSeconds(2), Duration.ofSeconds(3));
+
+        long start = System.nanoTime();
+        assertThatThrownBy(() ->
+                client.get().uri("/test").retrieve().bodyToMono(String.class).block())
+                .isInstanceOf(Exception.class);
+        long elapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+
+        assertThat(elapsed).as("3s 타임아웃이므로 5s 전에 끊어야 한다").isLessThan(4500);
+    }
+
+    @Test
+    @DisplayName("openai: 20초 타임아웃 — 정상 응답 성공")
+    void openai_normalResponse_succeeds() {
+        server.enqueue(new MockResponse()
+                .setBody("{\"ok\":true}")
+                .addHeader("Content-Type", "application/json"));
+
+        WebClient client = buildClient(Duration.ofSeconds(2), Duration.ofSeconds(20));
+
+        String result = client.get().uri("/test").retrieve().bodyToMono(String.class).block();
+        assertThat(result).contains("ok");
+    }
+
+    @Test
+    @DisplayName("kakaoOAuth: 3초 타임아웃 — 5초 지연 응답 시 타임아웃 예외 발생")
+    void kakaoOAuth_responseTimeout() {
+        server.enqueue(new MockResponse()
+                .setBody("{}")
+                .setHeadersDelay(5, TimeUnit.SECONDS));
+
+        WebClient client = buildClient(Duration.ofSeconds(2), Duration.ofSeconds(3));
+
+        long start = System.nanoTime();
+        assertThatThrownBy(() ->
+                client.get().uri("/test").retrieve().bodyToMono(String.class).block())
+                .isInstanceOf(Exception.class);
+        long elapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+
+        assertThat(elapsed).isLessThan(4500);
+    }
+}

--- a/src/test/java/io/github/ssforu/pin4u/features/home/HomeServiceQueryCountTest.java
+++ b/src/test/java/io/github/ssforu/pin4u/features/home/HomeServiceQueryCountTest.java
@@ -1,0 +1,79 @@
+package io.github.ssforu.pin4u.features.home;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.ssforu.pin4u.TestcontainersConfiguration;
+import io.github.ssforu.pin4u.features.home.application.HomeService;
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@Tag("integration")
+@SpringBootTest(properties = {
+    "spring.jpa.properties.hibernate.generate_statistics=true"
+})
+@Import(TestcontainersConfiguration.class)
+class HomeServiceQueryCountTest {
+
+    @Autowired
+    private HomeService homeService;
+
+    @Autowired
+    private EntityManagerFactory emf;
+
+    @Autowired
+    private JdbcTemplate jdbc;
+
+    private Statistics stats;
+
+    @BeforeEach
+    void setUp() {
+        stats = emf.unwrap(SessionFactory.class).getStatistics();
+        stats.setStatisticsEnabled(true);
+
+        jdbc.execute("DELETE FROM request_place_aggregates");
+        jdbc.execute("DELETE FROM requests");
+        jdbc.execute("DELETE FROM stations");
+        jdbc.execute(
+                "INSERT INTO users (id, nickname, preference_text, created_at, updated_at) "
+                        + "VALUES (999, 'test-user', 'test', now(), now()) ON CONFLICT (id) DO NOTHING");
+
+        jdbc.execute("""
+                INSERT INTO stations (code, name, line, lat, lng) VALUES
+                ('S0101', '강남', '2호선', 37.4979, 127.0276),
+                ('S0102', '역삼', '2호선', 37.5007, 127.0365)
+                """);
+
+        for (int i = 1; i <= 20; i++) {
+            String slug = "test-slug-" + i;
+            String stCode = i % 2 == 0 ? "S0101" : "S0102";
+            jdbc.update(
+                    "INSERT INTO requests (slug, station_code, owner_user_id, request_message, created_at) "
+                            + "VALUES (?, ?, ?, ?, now())",
+                    slug, stCode, 999L, "msg-" + i);
+        }
+    }
+
+    @Test
+    @DisplayName("요청 20건 조회 시 쿼리 수가 10개 이하 (N+1 없음)")
+    void dashboard_20requests_queryCountBelow10() {
+        stats.clear();
+
+        homeService.dashboard(999L);
+
+        long queryCount = stats.getQueryExecutionCount() + stats.getEntityLoadCount();
+        long prepareCount = stats.getPrepareStatementCount();
+
+        assertThat(prepareCount)
+                .as("요청 20건에 대해 prepared statement 10개 이하 (N+1 방지)")
+                .isLessThanOrEqualTo(10);
+    }
+}

--- a/src/test/java/io/github/ssforu/pin4u/features/requests/ConnectionOccupancyTest.java
+++ b/src/test/java/io/github/ssforu/pin4u/features/requests/ConnectionOccupancyTest.java
@@ -1,0 +1,93 @@
+package io.github.ssforu.pin4u.features.requests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.HikariPoolMXBean;
+import io.github.ssforu.pin4u.TestcontainersConfiguration;
+import io.github.ssforu.pin4u.features.requests.application.AiSummaryServiceImpl;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@Tag("integration")
+@SpringBootTest(properties = {
+    "app.ai.enabled=false",
+    "spring.datasource.hikari.maximum-pool-size=5",
+    "spring.datasource.hikari.minimum-idle=2"
+})
+@Import(TestcontainersConfiguration.class)
+class ConnectionOccupancyTest {
+
+    @Autowired
+    private AiSummaryServiceImpl aiSummaryService;
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Autowired
+    private JdbcTemplate jdbc;
+
+    @Test
+    @DisplayName("AI 비활성 상태에서 동시 10건 generateAndSaveSummary 실행 시 active connection이 pool 크기(5) 이하")
+    void concurrentSummary_doesNotExhaustPool() throws Exception {
+        jdbc.execute("DELETE FROM place_summaries");
+        jdbc.execute("DELETE FROM request_place_aggregates");
+        jdbc.execute("DELETE FROM requests");
+        jdbc.execute("DELETE FROM stations");
+        jdbc.execute(
+                "INSERT INTO users (id, nickname, preference_text, created_at, updated_at) "
+                        + "VALUES (1, 'conn-test-user', 'test', now(), now()) ON CONFLICT (id) DO NOTHING");
+
+        jdbc.execute("""
+                INSERT INTO stations (code, name, line, lat, lng)
+                VALUES ('S0101', '강남', '2호선', 37.4979, 127.0276)
+                """);
+        for (int i = 1; i <= 10; i++) {
+            jdbc.update(
+                    "INSERT INTO requests (slug, station_code, owner_user_id, request_message, created_at) "
+                            + "VALUES (?, 'S0101', 1, 'msg', now())",
+                    "conn-test-" + i);
+        }
+
+        HikariPoolMXBean pool = ((HikariDataSource) dataSource).getHikariPoolMXBean();
+
+        ExecutorService executor = Executors.newFixedThreadPool(10);
+        List<Future<?>> futures = new ArrayList<>();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        for (int i = 1; i <= 10; i++) {
+            final String slug = "conn-test-" + i;
+            futures.add(executor.submit(() -> {
+                try {
+                    latch.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                aiSummaryService.generateAndSaveSummary(slug);
+            }));
+        }
+
+        latch.countDown();
+
+        Thread.sleep(200);
+        int activeConnections = pool.getActiveConnections();
+
+        for (Future<?> f : futures) {
+            f.get(10, TimeUnit.SECONDS);
+        }
+        executor.shutdown();
+
+        assertThat(activeConnections)
+                .as("트랜잭션 3단 분리 덕분에 동시 10건 실행 중에도 active connection은 pool 크기(5) 이하")
+                .isLessThanOrEqualTo(5);
+    }
+}

--- a/src/test/java/io/github/ssforu/pin4u/features/stations/BulkInsertIdempotencyTest.java
+++ b/src/test/java/io/github/ssforu/pin4u/features/stations/BulkInsertIdempotencyTest.java
@@ -1,0 +1,61 @@
+package io.github.ssforu.pin4u.features.stations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.ssforu.pin4u.TestcontainersConfiguration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@Tag("integration")
+@SpringBootTest
+@Import(TestcontainersConfiguration.class)
+class BulkInsertIdempotencyTest {
+
+    @Autowired
+    private JdbcTemplate jdbc;
+
+    @Test
+    @DisplayName("같은 code로 2회 upsert 시 행 수 불변 + 값 갱신")
+    void upsert_sameCode_twice_rowCountUnchanged_valuesUpdated() {
+        jdbc.execute("DELETE FROM request_place_aggregates");
+        jdbc.execute("DELETE FROM requests");
+        jdbc.execute("DELETE FROM stations");
+
+        String upsertSql = """
+                INSERT INTO stations (code, name, line, lat, lng)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT (code) DO UPDATE SET
+                    name = EXCLUDED.name,
+                    line = EXCLUDED.line,
+                    lat  = EXCLUDED.lat,
+                    lng  = EXCLUDED.lng
+                """;
+
+        jdbc.update(upsertSql, "S0101", "강남", "2호선", 37.4979, 127.0276);
+        jdbc.update(upsertSql, "S0102", "역삼", "2호선", 37.5007, 127.0365);
+        jdbc.update(upsertSql, "S0103", "선릉", "2호선", 37.5045, 127.0489);
+
+        int countAfterFirst = jdbc.queryForObject("SELECT count(*) FROM stations", Integer.class);
+        assertThat(countAfterFirst).isEqualTo(3);
+
+        jdbc.update(upsertSql, "S0101", "강남역(수정)", "2호선", 37.4980, 127.0277);
+        jdbc.update(upsertSql, "S0102", "역삼역(수정)", "2호선", 37.5008, 127.0366);
+        jdbc.update(upsertSql, "S0103", "선릉역(수정)", "2호선", 37.5046, 127.0490);
+
+        int countAfterSecond = jdbc.queryForObject("SELECT count(*) FROM stations", Integer.class);
+        assertThat(countAfterSecond)
+                .as("2회 upsert 후에도 행 수는 동일해야 한다")
+                .isEqualTo(3);
+
+        String updatedName = jdbc.queryForObject(
+                "SELECT name FROM stations WHERE code = 'S0101'", String.class);
+        assertThat(updatedName)
+                .as("ON CONFLICT DO UPDATE로 값이 갱신되어야 한다")
+                .isEqualTo("강남역(수정)");
+    }
+}


### PR DESCRIPTION
## Summary
- MockWebServer 타임아웃 테스트: 3초 타임아웃 설정 시 5초 지연 응답에서 예외 발생 검증
- 서킷브레이커 상태 전이 테스트: CLOSED→OPEN 전이 + OPEN 상태 즉시 차단 + fallback 반환
- 쿼리 수 단언 테스트: HomeService 요청 20건 조회 시 prepared statement ≤10 (N+1 방지)
- Bulk Insert 멱등성 테스트: ON CONFLICT DO UPDATE로 2회 적재 시 행 수 불변 + 값 갱신
- 커넥션 점유 검증 테스트: 트랜잭션 3단 분리로 동시 10건 시 active connection ≤ pool(5)

단위 29건 + 통합 12건 = 41건 (이전 33건 대비 +8건)

## Test plan
- [x] `./gradlew spotlessCheck clean build` 통과 (단위 29건)
- [x] `./gradlew integrationTest` 통과 (통합 12건)
- [x] `@Disabled` 0건

Closes #81