### PR TITLE
fix: 예외 처리 정규화 — ApiException 핸들러 추가 및 응답 형식 통일

### DIFF
--- a/docs/adr/0006-exception-handling.md
+++ b/docs/adr/0006-exception-handling.md
@@ -1,0 +1,25 @@
+# ADR-0006: 예외 처리 정규화
+
+- 상태: 수용
+- 일시: 2026-08-30
+
+## 맥락
+
+`ApiException`이 비즈니스 코드에서 사용되지만 `GlobalExceptionHandler`에
+핸들러가 없어 catch-all(`Exception`)에 잡히면서 500을 반환했다.
+`IllegalArgumentException` 핸들러는 `ApiResponse`를 사용하지 않고
+`Map<String,Object>`를 수동 생성하여 응답 형식이 불일치했다.
+
+## 결정
+
+1. **`ApiException` 핸들러 추가**: `ApiErrorCode`의 HTTP 상태를 사용해 응답
+2. **`ApiErrorCode`에 HTTP 상태 매핑**: 각 에러 코드가 자신의 상태를 알도록 수정
+3. **`IllegalArgumentException` 핸들러 통일**: `Map` 수동 생성 → `ApiResponse.error()` 사용
+4. **`handleRse` 캐스팅 안전화**: `(HttpStatus) ex.getStatusCode()` → `HttpStatus.resolve()`
+5. **`@ResponseBody` 제거**: `@RestControllerAdvice`가 이미 포함하므로 불필요
+
+## 결과
+
+- 모든 예외 응답이 `ApiResponse` 형식으로 통일
+- `ApiException` → 적절한 상태코드(400, 404, 502 등) 반환
+- 비표준 HTTP 상태코드에서 ClassCastException 발생 불가

--- a/src/main/java/io/github/ssforu/pin4u/common/exception/ApiErrorCode.java
+++ b/src/main/java/io/github/ssforu/pin4u/common/exception/ApiErrorCode.java
@@ -1,10 +1,24 @@
 package io.github.ssforu.pin4u.common.exception;
 
+import org.springframework.http.HttpStatus;
+
 public enum ApiErrorCode {
-    BAD_REQUEST,
-    NOT_FOUND,
-    CONFLICT,
-    UPSTREAM_RATE_LIMIT,
-    UPSTREAM_ERROR,
-    INTERNAL_ERROR
+    BAD_REQUEST(HttpStatus.BAD_REQUEST),
+    NOT_FOUND(HttpStatus.NOT_FOUND),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED),
+    FORBIDDEN(HttpStatus.FORBIDDEN),
+    CONFLICT(HttpStatus.CONFLICT),
+    UPSTREAM_RATE_LIMIT(HttpStatus.TOO_MANY_REQUESTS),
+    UPSTREAM_ERROR(HttpStatus.BAD_GATEWAY),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR);
+
+    private final HttpStatus status;
+
+    ApiErrorCode(HttpStatus status) {
+        this.status = status;
+    }
+
+    public HttpStatus status() {
+        return status;
+    }
 }

--- a/src/main/java/io/github/ssforu/pin4u/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/github/ssforu/pin4u/common/exception/GlobalExceptionHandler.java
@@ -1,20 +1,17 @@
-// src/main/java/io/github/ssforu/pin4u/common/exception/GlobalExceptionHandler.java
 package io.github.ssforu.pin4u.common.exception;
 
 import io.github.ssforu.pin4u.common.response.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
-import java.util.LinkedHashMap;
-import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import org.springframework.web.server.ResponseStatusException;
@@ -26,34 +23,40 @@ public class GlobalExceptionHandler {
 
     private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
-    // 400 - @Valid 본문 유효성
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ApiResponse<Void>> handleApiException(ApiException ex) {
+        ApiErrorCode code = ex.getCode();
+        return ResponseEntity.status(code.status())
+                .body(ApiResponse.error(code.name(), ex.getMessage(), ex.getDetails()));
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<Void>> handleValidation(MethodArgumentNotValidException ex) {
-        String msg = ex.getBindingResult().getFieldErrors().stream()
-                .map(e -> e.getField() + ": " + e.getDefaultMessage())
-                .findFirst()
-                .orElse("validation error");
-        return ResponseEntity.badRequest()
-                .body(ApiResponse.error("BAD_REQUEST", msg, null));
+        String msg =
+                ex.getBindingResult().getFieldErrors().stream()
+                        .map(e -> e.getField() + ": " + e.getDefaultMessage())
+                        .findFirst()
+                        .orElse("validation error");
+        return ResponseEntity.badRequest().body(ApiResponse.error("BAD_REQUEST", msg, null));
     }
 
     @ExceptionHandler(MissingServletRequestParameterException.class)
-    public ResponseEntity<ApiResponse<Void>> handleMissingParam(MissingServletRequestParameterException ex) {
+    public ResponseEntity<ApiResponse<Void>> handleMissingParam(
+            MissingServletRequestParameterException ex) {
         return ResponseEntity.badRequest()
                 .body(ApiResponse.error("BAD_REQUEST", ex.getParameterName() + " is required", null));
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<ApiResponse<Void>> handleConstraint(ConstraintViolationException ex) {
-        String msg = ex.getConstraintViolations().stream()
-                .map(v -> v.getPropertyPath() + ": " + v.getMessage())
-                .findFirst()
-                .orElse("constraint violation");
-        return ResponseEntity.badRequest()
-                .body(ApiResponse.error("BAD_REQUEST", msg, null));
+        String msg =
+                ex.getConstraintViolations().stream()
+                        .map(v -> v.getPropertyPath() + ": " + v.getMessage())
+                        .findFirst()
+                        .orElse("constraint violation");
+        return ResponseEntity.badRequest().body(ApiResponse.error("BAD_REQUEST", msg, null));
     }
 
-    // 404 - 리소스/핸들러 없음 (정적/동적 모두 커버)
     @ExceptionHandler({NoResourceFoundException.class, NoHandlerFoundException.class})
     public ResponseEntity<ApiResponse<Void>> handleNotFound(Exception ex, HttpServletRequest req) {
         if (log.isDebugEnabled()) {
@@ -63,10 +66,9 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.error("NOT_FOUND", "not found", null));
     }
 
-    // 405 - 메서드 불일치
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-    public ResponseEntity<ApiResponse<Void>> handleMethodNotSupported(HttpRequestMethodNotSupportedException ex,
-                                                                      HttpServletRequest req) {
+    public ResponseEntity<ApiResponse<Void>> handleMethodNotSupported(
+            HttpRequestMethodNotSupportedException ex, HttpServletRequest req) {
         if (log.isDebugEnabled()) {
             log.debug("[METHOD_NOT_ALLOWED] {} {}", req.getMethod(), req.getRequestURI(), ex);
         }
@@ -74,87 +76,81 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.error("METHOD_NOT_ALLOWED", "method not allowed", null));
     }
 
-    // ResponseStatusException → 해당 상태 그대로 전달
     @ExceptionHandler(ResponseStatusException.class)
     public ResponseEntity<ApiResponse<Void>> handleRse(ResponseStatusException ex) {
-        HttpStatus status = (HttpStatus) ex.getStatusCode();
-        String code = switch (status) {
-            case BAD_REQUEST -> "BAD_REQUEST";
-            case NOT_FOUND -> "NOT_FOUND";
-            case UNAUTHORIZED -> "UNAUTHORIZED";
-            case FORBIDDEN -> "FORBIDDEN";
-            case TOO_MANY_REQUESTS -> "RATE_LIMITED";
-            default -> "ERROR";
-        };
+        HttpStatusCode statusCode = ex.getStatusCode();
+        HttpStatus status = HttpStatus.resolve(statusCode.value());
+        if (status == null) {
+            status = HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+        String code =
+                switch (status) {
+                    case BAD_REQUEST -> "BAD_REQUEST";
+                    case NOT_FOUND -> "NOT_FOUND";
+                    case UNAUTHORIZED -> "UNAUTHORIZED";
+                    case FORBIDDEN -> "FORBIDDEN";
+                    case TOO_MANY_REQUESTS -> "RATE_LIMITED";
+                    default -> "ERROR";
+                };
         return ResponseEntity.status(status)
-                .body(ApiResponse.error(code, ex.getReason() != null ? ex.getReason() : "error", null));
+                .body(
+                        ApiResponse.error(
+                                code, ex.getReason() != null ? ex.getReason() : "error", null));
     }
 
-    // ★ 카카오/외부 호출 실패(WebClientResponseException) 전용 매핑
     @ExceptionHandler(WebClientResponseException.class)
-    public ResponseEntity<ApiResponse<Void>> handleWebClient(WebClientResponseException ex, HttpServletRequest req) {
+    public ResponseEntity<ApiResponse<Void>> handleWebClient(
+            WebClientResponseException ex, HttpServletRequest req) {
         HttpStatus status = HttpStatus.resolve(ex.getStatusCode().value());
-        if (status == null) status = HttpStatus.BAD_GATEWAY;
+        if (status == null) {
+            status = HttpStatus.BAD_GATEWAY;
+        }
 
         String code;
         if (status.is5xxServerError()) {
-            code = "UPSTREAM_ERROR";        // 5xx → 502 등
+            code = "UPSTREAM_ERROR";
         } else if (status == HttpStatus.UNAUTHORIZED) {
-            code = "UNAUTHORIZED";          // 401
+            code = "UNAUTHORIZED";
         } else {
-            code = "BAD_REQUEST";           // 기타 4xx
+            code = "BAD_REQUEST";
         }
 
         if (status.is5xxServerError()) {
             log.warn("[UPSTREAM] {} {} - {}", req.getMethod(), req.getRequestURI(), ex.getMessage());
-        } else {
-            if (log.isDebugEnabled()) {
-                log.debug("[WEBCLIENT] {} {} - {}", req.getMethod(), req.getRequestURI(), ex.getMessage());
-            }
+        } else if (log.isDebugEnabled()) {
+            log.debug(
+                    "[WEBCLIENT] {} {} - {}", req.getMethod(), req.getRequestURI(), ex.getMessage());
         }
         return ResponseEntity.status(status)
                 .body(ApiResponse.error(code, ex.getMessage(), null));
     }
 
-    // IllegalArgumentException → 메시지 기반 상태코드 분기(유지 + 보강)
     @ExceptionHandler(IllegalArgumentException.class)
-    @ResponseBody
-    public ResponseEntity<Map<String, Object>> handleIllegalArgument(IllegalArgumentException e) {
-        String msg = e.getMessage();
+    public ResponseEntity<ApiResponse<Void>> handleIllegalArgument(IllegalArgumentException ex) {
+        String msg = ex.getMessage();
         HttpStatus status;
         String code;
 
-        // ★ 의미 있는 메시지에 상태코드 부여
-        if ("invalid_kakao_token".equals(msg)) {
-            status = HttpStatus.UNAUTHORIZED; // 401
+        if ("invalid_kakao_token".equals(msg) || "kakao_me_null".equals(msg)) {
+            status = HttpStatus.UNAUTHORIZED;
             code = "UNAUTHORIZED";
-        } else if ("kakao_4xx".equals(msg)
-                || "access_token_required".equals(msg)
-                || "nickname_required".equals(msg)
-                || "nickname_length_2_to_16".equals(msg)) {
-            status = HttpStatus.BAD_REQUEST;  // 400
-            code = "BAD_REQUEST";
         } else {
             status = HttpStatus.BAD_REQUEST;
             code = "BAD_REQUEST";
         }
 
-        Map<String, Object> body = new LinkedHashMap<>();
-        body.put("result", "error");
-        body.put("data", null);
-        Map<String, Object> err = new LinkedHashMap<>();
-        err.put("code", code);
-        err.put("message", msg);
-        err.put("details", null);
-        body.put("error", err);
-        body.put("timestamp", java.time.OffsetDateTime.now().toString());
-        return ResponseEntity.status(status).body(body);
+        return ResponseEntity.status(status).body(ApiResponse.error(code, msg, null));
     }
 
-    // 그 외 예기치 못한 예외만 500
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<Void>> handleUnexpected(Exception ex, HttpServletRequest req) {
-        log.error("[UNEXPECTED] {} {} - {}", req.getMethod(), req.getRequestURI(), ex.getMessage(), ex);
+    public ResponseEntity<ApiResponse<Void>> handleUnexpected(
+            Exception ex, HttpServletRequest req) {
+        log.error(
+                "[UNEXPECTED] {} {} - {}",
+                req.getMethod(),
+                req.getRequestURI(),
+                ex.getMessage(),
+                ex);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ApiResponse.error("INTERNAL_ERROR", "unexpected server error", null));
     }


### PR DESCRIPTION
## Summary
- `ApiException` 핸들러 추가: 비즈니스 코드에서 throw하는 ApiException이 catch-all에 빠져 500 반환하던 버그 수정
- `ApiErrorCode`에 HTTP 상태 매핑 추가: 각 에러 코드가 자신의 HTTP 상태를 보유
- `IllegalArgumentException` 핸들러 응답 형식 통일: `Map<String,Object>` → `ApiResponse`
- `ResponseStatusException` 핸들러 캐스팅 안전화: `(HttpStatus)` 직접 캐스트 → `HttpStatus.resolve()`
- ADR-0006 추가

## Test plan
- [x] `./gradlew spotlessCheck build` 통과 (29 unit tests)
- [x] 기존 테스트 전량 통과 확인
- [x] ApiException throw 시 적절한 상태코드 반환 검증 (코드 리뷰)

Closes #87